### PR TITLE
Update links to CDN license for fonts and icons to a dynamic URL

### DIFF
--- a/src/less/_Fabric.Icons.Font.less
+++ b/src/less/_Fabric.Icons.Font.less
@@ -6,7 +6,7 @@
 // Icon font-family definition
 
 /*
-  Your use of the content in the files referenced here are subject to the terms of the license at https://appsforoffice.microsoft.com/fabric/Segoe UI and Fabric CDN License.txt
+  Your use of the content in the files referenced here are subject to the terms of the license at http://aka.ms/fabric-font-license
 */
 
 

--- a/src/less/_Fabric.Typography.Fonts.less
+++ b/src/less/_Fabric.Typography.Fonts.less
@@ -25,7 +25,7 @@
 
 
 /*
-  Your use of the content in the files referenced here are subject to the terms of the license at https://appsforoffice.microsoft.com/fabric/Segoe UI and Fabric CDN License.txt
+  Your use of the content in the files referenced here are subject to the terms of the license at http://aka.ms/fabric-font-license
 */
 
 // Mixins to generate @font-face rules for unique languages.


### PR DESCRIPTION
Update links to CDN license for fonts and icons to a dynamic URL. The actual file name of the license may change, so this helps keep the source reference resilient.