### PR TITLE
Simplify bower path in postinstall script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "scripts": {
-    "postinstall": "node node_modules/bower/bin/bower install"
+    "postinstall": "bower install"
   },
   "devDependencies": {
     "bower": "^1.3.12",


### PR DESCRIPTION
Because npm scripts include npm bin-enabled modules in the "path" by default, we can simplify this.