### PR TITLE
Fixed DatePicker bug where navigating to a previous month fails

### DIFF
--- a/src/components/DatePicker/DatePicker.less
+++ b/src/components/DatePicker/DatePicker.less
@@ -230,7 +230,7 @@
   left: 0px;
   position: absolute;
   top: 0px;
-  width: 180px;
+  width: 140px;
   z-index: @ms-zIndex-middle;
   cursor: pointer;
 }


### PR DESCRIPTION
Modifed the DatePicker LESS file to fix a bug where navigating using the previous button fails. Another click area was covering the previous button which caused this bug.