### PR TITLE
remove protocol from CDN reference to avoid cross HTTP/HTTPS requests

### DIFF
--- a/ghdocs/GETTINGSTARTED.md
+++ b/ghdocs/GETTINGSTARTED.md
@@ -21,7 +21,7 @@
 To reference Fabric CSS from a CDN, just include a link in the `<head>` element on the page using Fabric:
 
 ```html
-<link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.min.css">
+<link rel="stylesheet" href="//appsforoffice.microsoft.com/fabric/1.0/fabric.min.css">
 ```
 
 The uncompressed, minified, and right-to-left CSS files are also available on the CDN.


### PR DESCRIPTION
While Office Add-ins will always be loaded from HTTPS, if the UI Fabric is used from a self-standing web app in HTTP, users will be error / warning when pulling across security boundaries. Remove the protocol so the browser will stick with the current page's protocol HTTP / HTTPS