### PR TITLE
Update persona presence size. Clean up persona markup in all applicable components.

### DIFF
--- a/src/components/OrgChart/OrgChart.Square.html
+++ b/src/components/OrgChart/OrgChart.Square.html
@@ -5,12 +5,10 @@
           <button class="ms-OrgChart-listItemBtn">
             <div class="ms-Persona ms-Persona--square">
               <div class="ms-Persona-imageArea">
-                <div class="ms-Persona-imageCircle">
-                  <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                  <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                </div>
-                <div class="ms-Persona-presence"></div>
+                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
               </div>
+              <div class="ms-Persona-presence"></div>
               <div class="ms-Persona-details">
                 <div class="ms-Persona-primaryText">Russel Miller</div>
                 <div class="ms-Persona-secondaryText">Sales</div>
@@ -22,12 +20,10 @@
           <button class="ms-OrgChart-listItemBtn">
             <div class="ms-Persona ms-Persona--square">
               <div class="ms-Persona-imageArea">
-                <div class="ms-Persona-imageCircle">
-                  <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                  <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                </div>
-                <div class="ms-Persona-presence"></div>
+                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
               </div>                            
+              <div class="ms-Persona-presence"></div>
               <div class="ms-Persona-details">
                 <div class="ms-Persona-primaryText">Douglas Fielder</div>
                 <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -44,12 +40,10 @@
           <button class="ms-OrgChart-listItemBtn">
             <div class="ms-Persona ms-Persona--square">
               <div class="ms-Persona-imageArea">
-                <div class="ms-Persona-imageCircle">
-                  <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                  <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                </div>
-                <div class="ms-Persona-presence"></div>
+                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
               </div>                            
+              <div class="ms-Persona-presence"></div>
               <div class="ms-Persona-details">
                 <div class="ms-Persona-primaryText">Grant Steel</div>
                 <div class="ms-Persona-secondaryText">Sales</div>
@@ -66,12 +60,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona ms-Persona--square">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Harvey Wallin</div>
               <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -83,12 +75,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona ms-Persona--square">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Marcus Lauer</div>
               <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -100,12 +90,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona ms-Persona--square">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Marcel Groce</div>
               <div class="ms-Persona-secondaryText">Delivery</div>
@@ -117,12 +105,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona ms-Persona--square">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Jessica Fischer</div>
               <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/OrgChart/OrgChart.html
+++ b/src/components/OrgChart/OrgChart.html
@@ -7,12 +7,10 @@
           <button class="ms-OrgChart-listItemBtn">
             <div class="ms-Persona">
               <div class="ms-Persona-imageArea">
-                <div class="ms-Persona-imageCircle">
-                  <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                  <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                </div>
-                <div class="ms-Persona-presence"></div>
+                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
               </div>
+              <div class="ms-Persona-presence"></div>
               <div class="ms-Persona-details">
                 <div class="ms-Persona-primaryText">Russel Miller</div>
                 <div class="ms-Persona-secondaryText">Sales</div>
@@ -24,12 +22,10 @@
           <button class="ms-OrgChart-listItemBtn">
             <div class="ms-Persona">
               <div class="ms-Persona-imageArea">
-                <div class="ms-Persona-imageCircle">
-                  <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                  <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                </div>
-                <div class="ms-Persona-presence"></div>
+                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
               </div>                            
+              <div class="ms-Persona-presence"></div>
               <div class="ms-Persona-details">
                 <div class="ms-Persona-primaryText">Douglas Fielder</div>
                 <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -46,12 +42,10 @@
           <button class="ms-OrgChart-listItemBtn">
             <div class="ms-Persona">
               <div class="ms-Persona-imageArea">
-                <div class="ms-Persona-imageCircle">
-                  <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                  <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                </div>
-                <div class="ms-Persona-presence"></div>
+                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
               </div>                            
+              <div class="ms-Persona-presence"></div>
               <div class="ms-Persona-details">
                 <div class="ms-Persona-primaryText">Grant Steel</div>
                 <div class="ms-Persona-secondaryText">Sales</div>
@@ -68,12 +62,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Harvey Wallin</div>
               <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -85,12 +77,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Marcus Lauer</div>
               <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -102,12 +92,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Marcel Groce</div>
               <div class="ms-Persona-secondaryText">Delivery</div>
@@ -119,12 +107,10 @@
         <button class="ms-OrgChart-listItemBtn">
           <div class="ms-Persona">
             <div class="ms-Persona-imageArea">
-              <div class="ms-Persona-imageCircle">
-                <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-              </div>
-              <div class="ms-Persona-presence"></div>
+              <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+              <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
             </div>                            
+            <div class="ms-Persona-presence"></div>
             <div class="ms-Persona-details">
               <div class="ms-Persona-primaryText">Jessica Fischer</div>
               <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/PeoplePicker/Jquery.PeoplePicker.js
+++ b/src/components/PeoplePicker/Jquery.PeoplePicker.js
@@ -79,8 +79,8 @@
                                    '<div class="ms-Persona-imageArea">' +
                                      '<i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>' +
                                      '<img class="ms-Persona-image" src="../persona/Persona.Person2.png">' +
-                                     '<div class="ms-Persona-presence"></div>' +
                                    '</div>' +
+                                   '<div class="ms-Persona-presence"></div>' +
                                    '<div class="ms-Persona-details">' +
                                      '<div class="ms-Persona-primaryText">' + selectedName + '</div>' +
                                   ' </div>' +

--- a/src/components/PeoplePicker/PeoplePicker.Compact.html
+++ b/src/components/PeoplePicker/PeoplePicker.Compact.html
@@ -14,8 +14,8 @@
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          <div class="ms-Persona-presence"></div>
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -29,8 +29,8 @@
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          <div class="ms-Persona-presence"></div>
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -49,8 +49,8 @@
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          <div class="ms-Persona-presence"></div>
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -63,8 +63,9 @@
                     <button class="ms-PeoplePicker-resultBtn ms-PeoplePicker-resultBtn--compact">
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -77,8 +78,9 @@
                     <button class="ms-PeoplePicker-resultBtn ms-PeoplePicker-resultBtn--compact">
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Grant Steel</div>
                           <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -93,8 +95,8 @@
                                   <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                                     <div class="ms-Persona-imageArea">
                                       <img class="ms-Persona-image" src="../persona/Persona.Person2.png">   
-                                      <div class="ms-Persona-presence"></div>
                                     </div>
+                                    <div class="ms-Persona-presence"></div>
                                     <div class="ms-Persona-details">
                                       <div class="ms-Persona-primaryText">Bill B. (billb)</div>
                                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -108,8 +110,8 @@
                                   <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                                     <div class="ms-Persona-imageArea">
                                       <img class="ms-Persona-image" src="../persona/Persona.Person2.png"> 
-                                      <div class="ms-Persona-presence"></div>
                                     </div>
+                                    <div class="ms-Persona-presence"></div>
                                     <div class="ms-Persona-details">
                                       <div class="ms-Persona-primaryText">Grant Steel (bask)</div>
                                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -125,8 +127,9 @@
                     <button class="ms-PeoplePicker-resultBtn ms-PeoplePicker-resultBtn--compact">
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Harvey Wallin</div>
                           <div class="ms-Persona-secondaryText">Delivery</div>
@@ -139,8 +142,9 @@
                     <button class="ms-PeoplePicker-resultBtn ms-PeoplePicker-resultBtn--compact">
                       <div class="ms-Persona ms-Persona--xs ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Marcus Lauer</div>
                           <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/PeoplePicker/PeoplePicker.Disconnected.html
+++ b/src/components/PeoplePicker/PeoplePicker.Disconnected.html
@@ -13,8 +13,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -27,8 +28,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -46,8 +48,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -60,8 +63,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -74,8 +78,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Grant Steel</div>
                           <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -90,8 +95,8 @@
                                   <div class="ms-Persona ms-Persona--square">
                                     <div class="ms-Persona-imageArea">
                                       <img class="ms-Persona-image" src="../persona/Persona.Person2.png"> 
-                                      <div class="ms-Persona-presence"></div>
                                     </div>
+                                    <div class="ms-Persona-presence"></div>
                                     <div class="ms-Persona-details">
                                       <div class="ms-Persona-primaryText">Bill B. (billb)</div>
                                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -105,8 +110,8 @@
                                   <div class="ms-Persona ms-Persona--square">
                                     <div class="ms-Persona-imageArea">
                                       <img class="ms-Persona-image" src="../persona/Persona.Person2.png">    
-                                      <div class="ms-Persona-presence"></div>
                                     </div>
+                                    <div class="ms-Persona-presence"></div>
                                     <div class="ms-Persona-details">
                                       <div class="ms-Persona-primaryText">Grant Steel (bask)</div>
                                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -122,8 +127,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Harvey Wallin</div>
                           <div class="ms-Persona-secondaryText">Delivery</div>
@@ -136,8 +142,9 @@
                     <button class="ms-PeoplePicker-resultBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Marcus Lauer</div>
                           <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/PeoplePicker/PeoplePicker.FacePile.html
+++ b/src/components/PeoplePicker/PeoplePicker.FacePile.html
@@ -14,8 +14,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -28,8 +29,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -43,8 +45,8 @@
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
                           <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          <div class="ms-Persona-presence"></div>
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Bill B. (billb)</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -58,8 +60,8 @@
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
                           <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          <div class="ms-Persona-presence"></div>
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Grant Steel (bask)</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -72,8 +74,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Harvey Wallin</div>
                           <div class="ms-Persona-secondaryText">Delivery</div>
@@ -86,8 +89,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Marcus Lauer</div>
                           <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/PeoplePicker/PeoplePicker.html
+++ b/src/components/PeoplePicker/PeoplePicker.html
@@ -14,8 +14,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -29,8 +30,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -49,8 +51,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -64,8 +67,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -79,8 +83,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Grant Steel</div>
                           <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -95,8 +100,9 @@
                                   <div class="ms-Persona ms-Persona--square">
                                     <div class="ms-Persona-imageArea">
                                       <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">                                      <div class="ms-Persona-presence"></div>
+                                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                                     </div>
+                                    <div class="ms-Persona-presence"></div>
                                     <div class="ms-Persona-details">
                                       <div class="ms-Persona-primaryText">Bill B. (billb)</div>
                                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -110,8 +116,9 @@
                                   <div class="ms-Persona ms-Persona--square">
                                     <div class="ms-Persona-imageArea">
                                       <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">                                      <div class="ms-Persona-presence"></div>
+                                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">           
                                     </div>
+                                    <div class="ms-Persona-presence"></div>
                                     <div class="ms-Persona-details">
                                       <div class="ms-Persona-primaryText">Grant Steel (bask)</div>
                                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -128,8 +135,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Harvey Wallin</div>
                           <div class="ms-Persona-secondaryText">Delivery</div>
@@ -143,8 +151,9 @@
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
                           <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png"><div class="ms-Persona-presence"></div>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Marcus Lauer</div>
                           <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/Persona/Persona.ExtraLarge.html
+++ b/src/components/Persona/Persona.ExtraLarge.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--xl">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.ExtraSmall.html
+++ b/src/components/Persona/Persona.ExtraSmall.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--xs">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
   </div>

--- a/src/components/Persona/Persona.Large.html
+++ b/src/components/Persona/Persona.Large.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--lg">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Available.html
+++ b/src/components/Persona/Persona.Presence.Available.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--available">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Away.html
+++ b/src/components/Persona/Persona.Presence.Away.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--away">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Blocked.html
+++ b/src/components/Persona/Persona.Presence.Blocked.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--blocked">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Busy.html
+++ b/src/components/Persona/Persona.Presence.Busy.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--busy">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Dnd.html
+++ b/src/components/Persona/Persona.Presence.Dnd.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--dnd">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Offline.html
+++ b/src/components/Persona/Persona.Presence.Offline.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--offline">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Square.Available.html
+++ b/src/components/Persona/Persona.Presence.Square.Available.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Square.Away.html
+++ b/src/components/Persona/Persona.Presence.Square.Away.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Square.Blocked.html
+++ b/src/components/Persona/Persona.Presence.Square.Blocked.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Square.Busy.html
+++ b/src/components/Persona/Persona.Presence.Square.Busy.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Square.Dnd.html
+++ b/src/components/Persona/Persona.Presence.Square.Dnd.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Presence.Square.Offline.html
+++ b/src/components/Persona/Persona.Presence.Square.Offline.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Small.html
+++ b/src/components/Persona/Persona.Small.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona ms-Persona--sm">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Square.ExtraLarge.html
+++ b/src/components/Persona/Persona.Square.ExtraLarge.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Square.ExtraSmall.html
+++ b/src/components/Persona/Persona.Square.ExtraSmall.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
   </div>

--- a/src/components/Persona/Persona.Square.Large.html
+++ b/src/components/Persona/Persona.Square.Large.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Square.Small.html
+++ b/src/components/Persona/Persona.Square.Small.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Square.Tiny.html
+++ b/src/components/Persona/Persona.Square.Tiny.html
@@ -1,9 +1,7 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <div class="ms-Persona ms-Persona ms-Persona--square ms-Persona--tiny">
-  <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-presence"></div>
-  </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
   </div>

--- a/src/components/Persona/Persona.Square.html
+++ b/src/components/Persona/Persona.Square.html
@@ -4,8 +4,8 @@
   <div class="ms-Persona-imageArea">
     <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
     <img class="ms-Persona-image" src="Persona.Person2.png">
-    <div class="ms-Persona-presence"></div>
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.Tiny.html
+++ b/src/components/Persona/Persona.Tiny.html
@@ -1,9 +1,7 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <div class="ms-Persona ms-Persona--tiny">
-  <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-presence"></div>
-  </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
   </div>

--- a/src/components/Persona/Persona.html
+++ b/src/components/Persona/Persona.html
@@ -2,12 +2,10 @@
 
 <div class="ms-Persona">
   <div class="ms-Persona-imageArea">
-    <div class="ms-Persona-imageCircle">
-      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-      <img class="ms-Persona-image" src="Persona.Person2.png">
-    </div>
-    <div class="ms-Persona-presence"></div>
+    <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+    <img class="ms-Persona-image" src="Persona.Person2.png">
   </div>
+  <div class="ms-Persona-presence"></div>
   <div class="ms-Persona-details">
     <div class="ms-Persona-primaryText">Alton Lafferty</div>
     <div class="ms-Persona-secondaryText">Accountant</div>

--- a/src/components/Persona/Persona.less
+++ b/src/components/Persona/Persona.less
@@ -19,8 +19,8 @@
 	display: block;
 	background-color: transparent;
 	overflow: hidden;
-	width: 50px;
-	height: 50px;
+	width: 52px;
+	height: 52px;
 	border-radius: 50%;
 	background-color: @ms-color-neutralTertiary;
 }
@@ -40,8 +40,8 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 50px;
-	height: 50px;
+	width: 52px;
+	height: 52px;
 
 	&[src=""] {
 		display: none;
@@ -88,13 +88,17 @@
 	color: @ms-color-neutralSecondary;
 	font-family: @ms-font-family-regular;
 	font-size: @ms-font-size-s;
-	padding-top: 8px;
 	white-space: nowrap;
 	line-height: 1.3
 }
 
+.ms-Persona-secondaryText {
+	padding-top: 3px;
+}
+
 .ms-Persona-tertiaryText, 
 .ms-Persona-optionalText {
+	padding-top: 5px;
 	display: none; // Hidden on default persona
 }
 
@@ -112,7 +116,7 @@
 		left: 0;
 		bottom: auto;
 		right: auto;
-		height: 50px;
+		height: 52px;
 		width: 5px;
 		border-radius: 0;
 		border: 0;
@@ -146,7 +150,7 @@
 
 	.ms-Persona-primaryText {
 		font-size: @ms-font-size-m;
-		padding-top: 11px;
+		padding-top: 9px;
 	}
 
 	.ms-Persona-secondaryText {
@@ -185,8 +189,8 @@
 .ms-Persona.ms-Persona--xs {
 	.ms-Persona-imageArea,
 	.ms-Persona-image {
-	  width: 30px;
-	  height: 30px;
+	  width: 32px;
+	  height: 32px;
 	}
 
 	.ms-Persona-placeholder {
@@ -217,7 +221,7 @@
 //
 .ms-Persona.ms-Persona--square.ms-Persona--xs {
 	.ms-Persona-presence {
-		height: 30px;
+		height: 32px;
 		width: 4px;
 		left: 0;
 	}
@@ -248,11 +252,11 @@
 
 	.ms-Persona-primaryText {
 		font-size: @ms-font-size-m;
-		padding-top: 1px;
 	}
 
+	.ms-Persona-primaryText,
 	.ms-Persona-secondaryText {
-		padding-top: 5px;
+		padding-top: 1px;
 	}
 }
 
@@ -273,8 +277,8 @@
 .ms-Persona.ms-Persona--lg {
 	.ms-Persona-imageArea,
 	.ms-Persona-image {
-	  width: 70px;
-	  height: 70px;
+	  width: 72px;
+	  height: 72px;
 	}
 
 	.ms-Persona-placeholder {
@@ -286,8 +290,12 @@
 		left: 49px;
 	}
 
-	.ms-Persona-primaryText {
-		font-family: @ms-font-family-regular;
+	.ms-Persona-secondaryText {
+		padding-top: 3px;
+	}
+
+	.ms-Persona-tertiaryText {
+		padding-top: 5px;
 	}
 
 	.ms-Persona-tertiaryText {
@@ -300,7 +308,7 @@
 //
 .ms-Persona.ms-Persona--square.ms-Persona--lg {
 	.ms-Persona-presence {
-		height: 70px;
+		height: 72px;
 		width: 7px;
 		left: 0;
 	}

--- a/src/components/Persona/Persona.less
+++ b/src/components/Persona/Persona.less
@@ -11,7 +11,6 @@
 	.ms-u-normalize;
 	display: table;
 	line-height: 1;
-	overflow: hidden;
 	position: relative;
 }
 
@@ -22,18 +21,8 @@
 	overflow: hidden;
 	width: 50px;
 	height: 50px;
-}
-
-.ms-Persona-imageCircle {
-  width: 50px;
-  height: 50px;
-  margin: 0;
-  border-radius: 50%;
-  overflow: hidden;
-  position: absolute;
-  left: 0;
-  right: 0;
-  background-color: @ms-color-neutralTertiary;
+	border-radius: 50%;
+	background-color: @ms-color-neutralTertiary;
 }
 
 .ms-Persona-placeholder {
@@ -62,20 +51,20 @@
 .ms-Persona-presence {
 	background-color: @ms-color-presence-available;
   position: absolute;
-  height: 10px;
-  width: 10px;
+  height: 12px;
+  width: 12px;
   border-radius: 50%;
   top: auto;
-  left: auto;
-  right: 2px;
+  left: 34px;
   bottom: -1px;
   border: 2px solid @ms-color-white;
 }
 
 .ms-Persona-details {
 	display: table-cell;
-	padding: 0 16px;
+	padding: 0 12px;
 	vertical-align: middle;
+	overflow: hidden;
 }
 
 .ms-Persona-primaryText {
@@ -107,6 +96,7 @@
 .ms-Persona.ms-Persona--square {
 	.ms-Persona-imageArea {
 		background-color: @ms-color-neutralTertiary;
+		border-radius: 0;
 	}
 
 	.ms-Persona-imageCircle {
@@ -130,7 +120,6 @@
 //
 .ms-Persona.ms-Persona--tiny {
 	height: 30px;
-	background-color: @ms-color-white;
 	display: inline-block;
 
 	.ms-Persona-imageArea {
@@ -146,14 +135,13 @@
 
 	.ms-Persona-presence {
 		right: auto;
-		height: 10px;
-		width: 10px;
 		top: 10px;
+		left: 0;
 		border: 0;
 	}
 
 	.ms-Persona-details {
-		padding-left: 18px;
+		padding-left: 20px;
 	}
 
 	.ms-Persona-primaryText {
@@ -185,13 +173,9 @@
 //
 .ms-Persona.ms-Persona--square.ms-Persona--tiny {
 	.ms-Persona-presence {
-		height: 10px;
-		width: 10px;
+		height: 12px;
+		width: 12px;
 		top: 10px;
-	}
-
-	.ms-Persona-details {
-		padding-left: 18px;
 	}
 }
 
@@ -212,10 +196,7 @@
 	}
 
 	.ms-Persona-presence {
-		height: 8px;
-		width: 8px;
-		right: -1px;
-		bottom: -1px;
+		left: 19px;
 	}
 
 	.ms-Persona-details {
@@ -239,6 +220,7 @@
 	.ms-Persona-presence {
 		height: 30px;
 		width: 4px;
+		left: 0;
 	}
 }
 
@@ -259,10 +241,7 @@
 	}
 
 	.ms-Persona-presence {
-		height: 10px;
-		width: 10px;
-		right: -1px;
-		bottom: -1px;
+		left: 27px;
 	}
 
 	.ms-Persona-details {
@@ -286,6 +265,7 @@
 	.ms-Persona-presence {
 		height: 40px;
 		width: 4px;
+		left: 0;
 	}
 }
 
@@ -306,8 +286,7 @@
 	}
 
 	.ms-Persona-presence {
-		height: 16px;
-		width: 16px;
+		left: 49px;
 	}
 
 	.ms-Persona-primaryText {
@@ -326,6 +305,7 @@
 	.ms-Persona-presence {
 		height: 70px;
 		width: 7px;
+		left: 0;
 	}
 }
 
@@ -346,8 +326,9 @@
 	}
 
 	.ms-Persona-presence {
-		height: 24px;
-		width: 24px;
+		height: 20px;
+		width: 20px;
+		left: 71px;
 	}
 
 	.ms-Persona-details {
@@ -378,6 +359,7 @@
 	.ms-Persona-presence {
 		height: 100px;
 		width: 9px;
+		left: 0;
 	}
 }
 

--- a/src/components/Persona/Persona.less
+++ b/src/components/Persona/Persona.less
@@ -67,12 +67,19 @@
 	overflow: hidden;
 }
 
+.ms-Persona-primaryText,
+.ms-Persona-secondaryText, 
+.ms-Persona-tertiaryText, 
+.ms-Persona-optionalText {
+	.noWrap();
+}
+
 .ms-Persona-primaryText {
 	color: @ms-color-neutralPrimary;
 	font-family: @ms-font-family-regular;
 	font-size: @ms-font-size-l;
 	margin-top: -3px;
-	white-space: nowrap;
+	line-height: 1.4;
 }
 
 .ms-Persona-secondaryText, 
@@ -83,6 +90,7 @@
 	font-size: @ms-font-size-s;
 	padding-top: 8px;
 	white-space: nowrap;
+	line-height: 1.3
 }
 
 .ms-Persona-tertiaryText, 
@@ -326,16 +334,16 @@
 	.ms-Persona-primaryText {
 		font-size: @ms-font-size-xl;
 		font-family: @ms-font-family-semilight;
-		margin-top: 2px;
+		margin-top: 0;
 	}
 
 	.ms-Persona-secondaryText {
-		padding-top: 7px;
+		padding-top: 2px;
 	}
 
 	.ms-Persona-tertiaryText, 
 	.ms-Persona-optionalText {
-		padding-top: 8px;
+		padding-top: 5px;
 		display: block; // Show tertiary and optional text
 	}
 }

--- a/src/components/Persona/Persona.less
+++ b/src/components/Persona/Persona.less
@@ -89,7 +89,7 @@
 	font-family: @ms-font-family-regular;
 	font-size: @ms-font-size-s;
 	white-space: nowrap;
-	line-height: 1.3
+	line-height: 1.3;
 }
 
 .ms-Persona-secondaryText {

--- a/src/components/Persona/Persona.less
+++ b/src/components/Persona/Persona.less
@@ -99,10 +99,6 @@
 		border-radius: 0;
 	}
 
-	.ms-Persona-imageCircle {
-		border-radius: 0;
-	}
-
 	.ms-Persona-presence {
 		top: 0;
 		left: 0;
@@ -127,10 +123,6 @@
 		background: transparent;
 		height: 0;
 		width: 0;
-	}
-
-	.ms-Persona-imageCircle {
-		display: none;
 	}
 
 	.ms-Persona-presence {
@@ -184,7 +176,6 @@
 //
 .ms-Persona.ms-Persona--xs {
 	.ms-Persona-imageArea,
-	.ms-Persona-imageCircle,
 	.ms-Persona-image {
 	  width: 30px;
 	  height: 30px;
@@ -229,7 +220,6 @@
 //
 .ms-Persona.ms-Persona--sm {
 	.ms-Persona-imageArea,
-	.ms-Persona-imageCircle,
 	.ms-Persona-image {
 	  width: 40px;
 	  height: 40px;
@@ -274,7 +264,6 @@
 //
 .ms-Persona.ms-Persona--lg {
 	.ms-Persona-imageArea,
-	.ms-Persona-imageCircle,
 	.ms-Persona-image {
 	  width: 70px;
 	  height: 70px;
@@ -314,7 +303,6 @@
 //
 .ms-Persona.ms-Persona--xl {
 	.ms-Persona-imageArea,
-	.ms-Persona-imageCircle,
 	.ms-Persona-image {
 	  width: 100px;
 	  height: 100px;

--- a/src/components/PersonaCard/PersonaCard.Square.html
+++ b/src/components/PersonaCard/PersonaCard.Square.html
@@ -2,12 +2,10 @@
   <div class="ms-PersonaCard-persona">
     <div class="ms-Persona ms-Persona--square ms-Persona--xl">
       <div class="ms-Persona-imageArea">
-        <div class="ms-Persona-imageCircle">
-          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-        </div>
-        <div class="ms-Persona-presence"></div>          
+        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
       </div>
+      <div class="ms-Persona-presence"></div>          
       <div class="ms-Persona-details">
         <div class="ms-Persona-primaryText">Alton Lafferty</div>
         <div class="ms-Persona-secondaryText">Interior Designer, Contoso</div>
@@ -49,12 +47,10 @@
                     <button class="ms-OrgChart-listItemBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <div class="ms-Persona-imageCircle">
-                            <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                            <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          </div>
-                          <div class="ms-Persona-presence"></div>
+                          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -66,12 +62,10 @@
                     <button class="ms-OrgChart-listItemBtn">
                       <div class="ms-Persona ms-Persona--square">
                         <div class="ms-Persona-imageArea">
-                          <div class="ms-Persona-imageCircle">
-                            <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                            <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          </div>
-                          <div class="ms-Persona-presence"></div>
+                          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>                            
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -88,12 +82,10 @@
                   <button class="ms-OrgChart-listItemBtn">
                     <div class="ms-Persona ms-Persona--square">
                       <div class="ms-Persona-imageArea">
-                        <div class="ms-Persona-imageCircle">
-                          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                        </div>
-                        <div class="ms-Persona-presence"></div>
+                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                       </div>                            
+                      <div class="ms-Persona-presence"></div>
                       <div class="ms-Persona-details">
                         <div class="ms-Persona-primaryText">Grant Steel</div>
                         <div class="ms-Persona-secondaryText">Sales</div>
@@ -110,12 +102,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona ms-Persona--square">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>                            
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Harvey Wallin</div>
                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -127,12 +117,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona ms-Persona--square">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>                            
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Marcus Lauer</div>
                       <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -144,12 +132,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona ms-Persona--square">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>                            
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Marcel Groce</div>
                       <div class="ms-Persona-secondaryText">Delivery</div>
@@ -161,12 +147,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona ms-Persona--square">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>                            
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Jessica Fischer</div>
                       <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/PersonaCard/PersonaCard.html
+++ b/src/components/PersonaCard/PersonaCard.html
@@ -2,16 +2,13 @@
 
 <div class="ms-PersonaCard">
   <div class="ms-PersonaCard-persona">
-    <div class="ms-Persona">
+    <div class="ms-Persona ms-Persona--xl">
       <div class="ms-Persona-imageArea">
-        <div class="ms-Persona-imageCircle">
-          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-        </div>
-        <div class="ms-Persona-presence"></div>
+        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
       </div>
+      <div class="ms-Persona-presence"></div>
       <div class="ms-Persona-details">
-        <!-- Use title attribute to display full text in the event of primaryText truncation -->
         <div class="ms-Persona-primaryText" title="Alton Lafferty">Alton Lafferty</div>
         <div class="ms-Persona-secondaryText">Interior Designer, Contoso</div>
         <div class="ms-Persona-tertiaryText">Office: 7/1234</div>
@@ -52,12 +49,10 @@
                     <button class="ms-OrgChart-listItemBtn">
                       <div class="ms-Persona">
                         <div class="ms-Persona-imageArea">
-                          <div class="ms-Persona-imageCircle">
-                            <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                            <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          </div>
-                          <div class="ms-Persona-presence"></div>
+                          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Russel Miller</div>
                           <div class="ms-Persona-secondaryText">Sales</div>
@@ -69,12 +64,10 @@
                     <button class="ms-OrgChart-listItemBtn">
                       <div class="ms-Persona">
                         <div class="ms-Persona-imageArea">
-                          <div class="ms-Persona-imageCircle">
-                            <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                            <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                          </div>
-                          <div class="ms-Persona-presence"></div>
+                          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                         </div>
+                        <div class="ms-Persona-presence"></div>
                         <div class="ms-Persona-details">
                           <div class="ms-Persona-primaryText">Douglas Fielder</div>
                           <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -91,12 +84,10 @@
                   <button class="ms-OrgChart-listItemBtn">
                     <div class="ms-Persona">
                       <div class="ms-Persona-imageArea">
-                        <div class="ms-Persona-imageCircle">
-                          <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                          <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                        </div>
-                        <div class="ms-Persona-presence"></div>
+                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                       </div>
+                      <div class="ms-Persona-presence"></div>
                       <div class="ms-Persona-details">
                         <div class="ms-Persona-primaryText">Grant Steel</div>
                         <div class="ms-Persona-secondaryText">Sales</div>
@@ -113,12 +104,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Harvey Wallin</div>
                       <div class="ms-Persona-secondaryText">Public Relations</div>
@@ -130,12 +119,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Marcus Lauer</div>
                       <div class="ms-Persona-secondaryText">Technical Support</div>
@@ -147,12 +134,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Marcel Groce</div>
                       <div class="ms-Persona-secondaryText">Delivery</div>
@@ -164,12 +149,10 @@
                 <button class="ms-OrgChart-listItemBtn">
                   <div class="ms-Persona">
                     <div class="ms-Persona-imageArea">
-                      <div class="ms-Persona-imageCircle">
-                        <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
-                        <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
-                      </div>
-                      <div class="ms-Persona-presence"></div>
+                      <i class="ms-Persona-placeholder ms-Icon ms-Icon--person"></i>
+                      <img class="ms-Persona-image" src="../persona/Persona.Person2.png">
                     </div>
+                    <div class="ms-Persona-presence"></div>
                     <div class="ms-Persona-details">
                       <div class="ms-Persona-primaryText">Jessica Fischer</div>
                       <div class="ms-Persona-secondaryText">Marketing</div>

--- a/src/components/PersonaCard/PersonaCard.less
+++ b/src/components/PersonaCard/PersonaCard.less
@@ -21,18 +21,16 @@
 
 .ms-PersonaCard-persona {
   background-color: @ms-color-neutralLighter;
+}
 
-  // Overrides for persona
+// Overrides for persona
+.ms-PersonaCard-persona .ms-Persona {
   .ms-Persona-imageArea {
-    width: 104px;
-    height: 104px;
-  }
-
-  .ms-Persona-imageCircle {
+    width: 80px;
+    height: 80px;
     margin: 12px 0 12px 20px;
   }
 
-  .ms-Persona-imageCircle,
   .ms-Persona-image {
     width: 80px;
     height: 80px;
@@ -45,15 +43,9 @@
   }
 
   .ms-Persona-presence {
-    height: 12px;
-    width: 12px;
     border-color: @ms-color-neutralLighter;
-    right: 8px;
+    left: 77px;
     bottom: 12px;
-  }
-
-  .ms-Persona-primaryText {
-    margin-top: 3px; // Move the text down to the next baseline
   }
 
   .ms-Persona-tertiaryText,
@@ -257,14 +249,16 @@
 //== Modifier: Persona card with square personas
 //
 .ms-PersonaCard.ms-PersonaCard--square {
-
   .ms-PersonaCard-persona {
-    .ms-Persona-imageCircle {
+    .ms-Persona-imageArea,
+    .ms-Persona-image {
+      width: 100px;
+      height: 100px;
       margin: 0;
     }
 
-    .ms-Persona-primaryText {
-      font-size: @ms-font-size-l;
+    .ms-Persona-presence {
+      left: 0;
     }
   }
 }


### PR DESCRIPTION
- Presence updated in persona component to match latest sizes in redlines. 
- Markup for persona updated - removed ms-Persona-imageCircle - unnecessary extra div between ms-Persona-imageArea and image. Less updated to account for this change for circle and square variants.
- Persona, PersonaCard, OrgChart, PeoplePicker updated with latest persona markup.