### PR TITLE
Fix: DatePicker on top of other DatePicker with correct z-index

### DIFF
--- a/src/components/DatePicker/DatePicker.less
+++ b/src/components/DatePicker/DatePicker.less
@@ -32,7 +32,7 @@
   position: absolute;
   right:  5px;
   bottom: 5px;
-  z-index: @ms-zIndex-front;
+  z-index: @ms-zIndex-middle;
 }
 
 // The holder is the only "scrollable" top-level container element.
@@ -53,6 +53,12 @@
     .drop-shadow;
     border: 1px solid @ms-color-neutralLight;
     display: block;
+}
+
+// When the picker opens, always open in front of possible other picker that is close
+.ms-DatePicker-picker--focused.ms-DatePicker-picker--opened { 
+  position:relative; 
+  z-index:@ms-zIndex-front; 
 }
 
 

--- a/src/components/DatePicker/DatePicker.less
+++ b/src/components/DatePicker/DatePicker.less
@@ -55,10 +55,10 @@
     display: block;
 }
 
-// When the picker opens, always open in front of possible other picker that is close
+// When a picker opens, always open it in front of other closed pickers
 .ms-DatePicker-picker--focused.ms-DatePicker-picker--opened { 
-  position:relative; 
-  z-index:@ms-zIndex-front; 
+  position: relative; 
+  z-index: @ms-zIndex-front; 
 }
 
 


### PR DESCRIPTION
This will fix the issue when two datepickers are used above each other. For example when using a start and end date. 