### PR TITLE
Fix: Click on navBar crashed with null reference without search box

### DIFF
--- a/src/components/NavBar/Jquery.NavBar.js
+++ b/src/components/NavBar/Jquery.NavBar.js
@@ -79,10 +79,11 @@
 
       // Hide any menus and close the search box when clicking anywhere in the document.
       $(document).on('click', 'html', function(event) {
+		var $searchBox = $navBar.find('.ms-NavBar-item.ms-NavBar-item--search .ms-TextField-field');  
         $navBar.find('.ms-NavBar-item').removeClass('is-selected').find('.ms-ContextualMenu').removeClass('is-open');
 
         // Close and blur the search box if it doesn't have text.
-        if ($navBar.find('.ms-NavBar-item.ms-NavBar-item--search .ms-TextField-field').val().length === 0) {
+        if ($searchBox.length > 0 && $searchBox.val().length === 0) {
           $navBar.find('.ms-NavBar-item.ms-NavBar-item--search').removeClass('is-open').find('.ms-TextField-field').blur();
         }
       });

--- a/src/components/NavBar/Jquery.NavBar.js
+++ b/src/components/NavBar/Jquery.NavBar.js
@@ -26,6 +26,7 @@
 
       // Set selected states and open/close menus.
       $navBar.on('click', '.ms-NavBar-item:not(.is-disabled)', function(event) {
+        var $searchBox = $navBar.find('.ms-NavBar-item.ms-NavBar-item--search .ms-TextField-field');
         event.stopPropagation();
 
         // Prevent default actions from firing if links are not found.
@@ -37,7 +38,7 @@
         $(this).siblings('.ms-NavBar-item').removeClass('is-selected');
 
         // Close and blur the search box if it doesn't have text.
-        if ($navBar.find('.ms-NavBar-item.ms-NavBar-item--search .ms-TextField-field').val().length === 0) {
+        if ($searchBox.length > 0 && $searchBox.val().length === 0) {
           $('.ms-NavBar-item.ms-NavBar-item--search').removeClass('is-open').find('.ms-TextField-field').blur();
         }
 


### PR DESCRIPTION
The NavBar plugin crashes when an item is clicked and no search box element is present.