### PR TITLE
Add presence colors to persona card

### DIFF
--- a/src/components/PersonaCard/PersonaCard.less
+++ b/src/components/PersonaCard/PersonaCard.less
@@ -272,3 +272,20 @@
     position: relative;
   }
 }
+
+// Presence colors
+.ms-PersonaCard.ms-PersonaCard--busy .ms-Persona-presence {
+  background-color: @ms-color-presence-busy;
+}
+.ms-PersonaCard.ms-PersonaCard--away .ms-Persona-presence {
+  background-color: @ms-color-presence-away;
+}
+.ms-PersonaCard.ms-PersonaCard--blocked .ms-Persona-presence {
+  background-color: @ms-color-presence-blocked-background;
+}
+.ms-PersonaCard.ms-PersonaCard--dnd .ms-Persona-presence {
+  background-color: @ms-color-presence-dnd-background;
+}
+.ms-PersonaCard.ms-PersonaCard--offline .ms-Persona-presence {
+  background-color: @ms-color-presence-offline;
+}


### PR DESCRIPTION
The **persona card** styles seem to only support the _available_ status, while the **persona** control supports busy, offline, dnd, away, etc.. I added these form looking at the persona control and matching the less variables. Please verify these are correct and I've added them to the right place.

Here's a codepen of these changes in action (explicit HEX colors replaced the variables):
http://codepen.io/andrewconnell/pen/NGRvxW

![screen shot 2015-09-24 at 6 12 07 am](https://cloud.githubusercontent.com/assets/2068657/10074197/36dda84e-6283-11e5-8efb-9ee7a3315849.png)
