### PR TITLE
Mark package.json and bower.json as non-private

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/OfficeDev/Office-UI-Fabric"
   },
-  "private": true,
+  "private": false,
   "ignore": [
     "node_modules",
     "bower_components"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/OfficeDev/Office-UI-Fabric"
   },
-  "private": true,
+  "private": false,
   "scripts": {
     "postinstall": "bower install"
   },


### PR DESCRIPTION
Mark package.json and bower.json as non-private so they can be published to their respective registries.