### PR TITLE
Remove Bower dependency and postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,7 @@
     "url": "https://github.com/OfficeDev/Office-UI-Fabric"
   },
   "private": false,
-  "scripts": {
-    "postinstall": "bower install"
-  },
   "devDependencies": {
-    "bower": "^1.3.12",
     "browser-sync": "^2.8.2",
     "colors": "^1.1.0",
     "del": "^1.2.1",


### PR DESCRIPTION
Remove Bower dependency and postinstall script from package.json. Both of these are remnants from pre-1.0 releases.