### PR TITLE
Fix for scroll on small screen devices.

### DIFF
--- a/src/components/Dropdown/Dropdown.less
+++ b/src/components/Dropdown/Dropdown.less
@@ -101,6 +101,7 @@
   top: 0;
   right: 0;
   bottom: 0;
+  overflow-y: scroll;
 
   &:before {
     content: '';
@@ -173,7 +174,6 @@
     right: auto;
     bottom: auto;
     left: auto;
-    overflow-y: scroll;
     max-width: 100%;
   }
 


### PR DESCRIPTION
ms-Dropdown-items should always have "overflow-y: scroll, not only on screen sizes above 480px.