### PR TITLE
DatePicker month button fix

### DIFF
--- a/src/components/DatePicker/DatePicker.less
+++ b/src/components/DatePicker/DatePicker.less
@@ -320,22 +320,6 @@
   }
 }
 
-// State: The picker is showing the month components.
-.ms-DatePicker.is-pickingMonths {
-
-  // Hide the day picking components.
-  .ms-DatePicker-dayPicker,
-  .ms-DatePicker-monthComponents {
-    display: none;
-  }
-
-  // Show the month picking components.
-  .ms-DatePicker-monthPicker {
-    display: block;
-  }
-
-}
-
 // State: The picker is showing the year components.
 .ms-DatePicker.is-pickingYears {
 
@@ -526,6 +510,25 @@
 
     // Show the year picking components.
     .ms-DatePicker-yearPicker {
+      display: block;
+    }
+  }
+}
+
+//on smaller screens the month button toggles to the picking months state
+@media (max-width: 459px) {
+
+  // State: The picker is showing the month components.
+  .ms-DatePicker.is-pickingMonths {
+
+    // Hide the day picking components.
+    .ms-DatePicker-dayPicker,
+    .ms-DatePicker-monthComponents {
+      display: none;
+    }
+
+    // Show the month picking components.
+    .ms-DatePicker-monthPicker {
       display: block;
     }
   }

--- a/src/components/DatePicker/DatePicker.less
+++ b/src/components/DatePicker/DatePicker.less
@@ -341,9 +341,6 @@
 
 }
 
-
-
-
 // 460px and up.
 //
 // On screens that can fit it, we show the month picker next to the day picker at all times.

--- a/src/components/DatePicker/DatePicker.less
+++ b/src/components/DatePicker/DatePicker.less
@@ -515,7 +515,7 @@
   }
 }
 
-//on smaller screens the month button toggles to the picking months state
+// On smaller screens the month button toggles to the picking months state.
 @media (max-width: 459px) {
 
   // State: The picker is showing the month components.


### PR DESCRIPTION
The month button was toggling to a state that only existed on smaller screens. A media query was added to prevent this from happening on screens larger than 459px.