### PR TITLE
expose pickadate objects to user

### DIFF
--- a/src/components/DatePicker/Jquery.DatePicker.js
+++ b/src/components/DatePicker/Jquery.DatePicker.js
@@ -8,7 +8,7 @@
 
   $.fn.DatePicker = function (options) {
 
-    return this.each(function () {
+    var picker = this.map(function () {
 
       /** Set up variables and run the Pickadate plugin. */
       var $datePicker = $(this);
@@ -82,7 +82,11 @@
         }
       });
 
-    });
+      return $picker;
+      
+    }).get();
+    
+    return picker;
   };
 
   /**


### PR DESCRIPTION
so the user can manipulate the input (including setting date and it's format)
also, the right version's pickadate docs should probably be linked in DatePicker's docs.