### PR TITLE
Updated bower.json with main section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,11 @@
     "type": "git",
     "url": "https://github.com/OfficeDev/Office-UI-Fabric"
   },
+  "main": [
+    "dist/css/fabric.css",
+    "dist/css/fabric.components.css",
+    "dist/js/jquery.fabric.js"
+  ],
   "private": false,
   "ignore": [
     "node_modules",


### PR DESCRIPTION
To fully support bower the main section is missing in the bower.json file. I updated this to make Office UI Fabric easier to use and inject the code using wiredep.
This should be merged because a newer version of Microsoft 'yo office!' rely on this enhancement.