### PR TITLE
Add missing ms-Icon SASS mixin

### DIFF
--- a/src/sass/Fabric.Icons.Output.scss
+++ b/src/sass/Fabric.Icons.Output.scss
@@ -6,16 +6,11 @@
 // Icon definitions
 
 
+@import './Fabric.Icons';
+
 // Base icon definition
 .ms-Icon {
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  display: inline-block;
-  font-family: 'Office365Icons';
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1;
-  speak: none;
+  @include ms-Icon();
 }
 
 // Modifiers: Each of the icons.

--- a/src/sass/_Fabric.Common.scss
+++ b/src/sass/_Fabric.Common.scss
@@ -2,6 +2,7 @@
 @import "./Fabric.Color.Mixins";
 @import "./Fabric.Color.Variables";
 @import "./Fabric.Grid";
+@import "./Fabric.Icons";
 @import "./Fabric.Mixins";
 @import "./Fabric.Responsive.Variables";
 @import "./Fabric.Typography";

--- a/src/sass/_Fabric.Icons.scss
+++ b/src/sass/_Fabric.Icons.scss
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+//
+// Office UI Fabric
+// --------------------------------------------------
+// Icon definitions
+
+@mixin ms-Icon {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-family: 'Office365Icons';
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  speak: none;
+}


### PR DESCRIPTION
This adds a missing mixin for ms-Icon to the core SASS files that were missed in the initial conversion from LESS.