### PR TITLE
Updates to Segoe font face/font stack

### DIFF
--- a/src/less/_Fabric.Typography.Fonts.less
+++ b/src/less/_Fabric.Typography.Fonts.less
@@ -32,10 +32,10 @@
 .SegoeUILight(@ms-font-language, @ms-font-path) {
   @font-face {
     font-family: "@{ms-light} @{ms-font-language}";
-    src: url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Light.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI Light"),
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Light.woff2') format('woff2'),
          url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Light.woff') format('woff'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Light.ttf') format('truetype'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Light.svg#SegoeUI-Light') format('svg');
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Light.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }
@@ -44,10 +44,10 @@
 .SegoeUIRegular(@ms-font-language, @ms-font-path) {
   @font-face {
     font-family: "@{ms-regular} @{ms-font-language}";
-    src: url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Regular.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI"),
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Regular.woff2') format('woff2'),
          url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Regular.woff') format('woff'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Regular.ttf') format('truetype'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Regular.svg#SegoeUI-Regular') format('svg');
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }
@@ -56,10 +56,10 @@
 .SegoeUISemilight(@ms-font-language, @ms-font-path) {
   @font-face {
     font-family: "@{ms-semilight} @{ms-font-language}";
-    src: url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semilight.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI Semilight"),
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semilight.woff2') format('woff2'),
          url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semilight.woff') format('woff'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semilight.ttf') format('truetype'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semilight.svg#SegoeUI-Semilight') format('svg');
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semilight.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }
@@ -68,10 +68,10 @@
 .SegoeUISemibold(@ms-font-language, @ms-font-path) {
   @font-face {
     font-family: "@{ms-semibold} @{ms-font-language}";
-    src: url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semibold.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI Semibold"),
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semibold.woff2') format('woff2'),
          url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semibold.woff') format('woff'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semibold.ttf') format('truetype'),
-         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semibold.svg#SegoeUI-Semibold') format('svg');
+         url('@{ms-font-directory}/@{ms-font-path}/SegoeUI-Semibold.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }

--- a/src/less/_Fabric.Typography.Languageoverrides.less
+++ b/src/less/_Fabric.Typography.Languageoverrides.less
@@ -34,14 +34,14 @@
 }
 
 // Base font stack.
-@ms-font-system-base: 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
+@ms-font-system-base: 'Segoe UI', Tahoma, Arial, sans-serif;
 
 // Variables for each of the non-distributed (native) font stacks.
-@ms-font-stack-japanese: YuGothic, "Meiryo UI", Meiryo, "MS Pgothic", Osaka, @ms-font-system-base;
-@ms-font-stack-korean: "Malgun Gothic", Gulim, @ms-font-system-base;
-@ms-font-stack-chinese-simplified: "Microsoft Yahei", Verdana, Simsun, @ms-font-system-base;
-@ms-font-stack-chinese-traditional: "Microsoft Jhenghei", Pmingliu, @ms-font-system-base;
-@ms-font-stack-hindi: "Nirmala UI", @ms-font-system-base;
+@ms-font-stack-japanese: 'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, @ms-font-system-base;
+@ms-font-stack-korean: 'Malgun Gothic', Gulim, @ms-font-system-base;
+@ms-font-stack-chinese-simplified: 'Microsoft Yahei', Verdana, Simsun, @ms-font-system-base;
+@ms-font-stack-chinese-traditional: 'Microsoft JhengHei', Pmingliu, @ms-font-system-base;
+@ms-font-stack-hindi: 'Nirmala UI', @ms-font-system-base;
 
 // Generate the override classes for non-distributed fonts.
 .language-override-system-fonts(ja-JP, @ms-font-stack-japanese);

--- a/src/less/_Fabric.Typography.Variables.less
+++ b/src/less/_Fabric.Typography.Variables.less
@@ -6,10 +6,10 @@
 // Fabric Core Typography variables
 
 
-@ms-font-family-light:     'Segoe UI Light WestEuropean', 'Segoe UI Light', 'Segoe WP Light', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
-@ms-font-family-regular:   'Segoe UI Regular WestEuropean', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
-@ms-font-family-semilight: 'Segoe UI Semilight WestEuropean', 'Segoe UI Semilight', 'Segoe WP Semilight', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
-@ms-font-family-semibold:  'Segoe UI Semibold WestEuropean', 'Segoe UI Semibold', 'Segoe WP Semibold', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
+@ms-font-family-light:     'Segoe UI Light WestEuropean', 'Segoe UI Light', 'Segoe UI', Tahoma, Arial, sans-serif;
+@ms-font-family-regular:   'Segoe UI Regular WestEuropean', 'Segoe UI', Tahoma, Arial, sans-serif;
+@ms-font-family-semilight: 'Segoe UI Semilight WestEuropean', 'Segoe UI Semilight', 'Segoe UI', Tahoma, Arial, sans-serif;
+@ms-font-family-semibold:  'Segoe UI Semibold WestEuropean', 'Segoe UI Semibold', 'Segoe UI', Tahoma, Arial, sans-serif;
 
 
 //== Type sizes

--- a/src/sass/_Fabric.Typography.Fonts.scss
+++ b/src/sass/_Fabric.Typography.Fonts.scss
@@ -32,10 +32,10 @@ $ms-font-path-westeuropean: "SegoeUI-WestEuropean";
 @mixin SegoeUILight($ms-font-language, $ms-font-path) {
   @font-face {
     font-family: "#{$ms-light} #{$ms-font-language}";
-    src: url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Light.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI Light"),
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Light.woff2') format('woff2'),
          url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Light.woff') format('woff'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Light.ttf') format('truetype'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Light.svg#SegoeUI-Light') format('svg');
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Light.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }
@@ -44,10 +44,10 @@ $ms-font-path-westeuropean: "SegoeUI-WestEuropean";
 @mixin SegoeUIRegular($ms-font-language, $ms-font-path) {
   @font-face {
     font-family: "#{$ms-regular} #{$ms-font-language}";
-    src: url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Regular.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI"),
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Regular.woff2') format('woff2'),
          url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Regular.woff') format('woff'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Regular.ttf') format('truetype'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Regular.svg#SegoeUI-Regular') format('svg');
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }
@@ -56,10 +56,10 @@ $ms-font-path-westeuropean: "SegoeUI-WestEuropean";
 @mixin SegoeUISemilight($ms-font-language, $ms-font-path) {
   @font-face {
     font-family: "#{$ms-semilight} #{$ms-font-language}";
-    src: url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semilight.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI Semilight"),
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semilight.woff2') format('woff2'),
          url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semilight.woff') format('woff'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semilight.ttf') format('truetype'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semilight.svg#SegoeUI-Semilight') format('svg');
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semilight.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }
@@ -68,10 +68,10 @@ $ms-font-path-westeuropean: "SegoeUI-WestEuropean";
 @mixin SegoeUISemibold($ms-font-language, $ms-font-path) {
   @font-face {
     font-family: "#{$ms-semibold} #{$ms-font-language}";
-    src: url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semibold.eot?#iefix') format('embedded-opentype'),
+    src: local("Segoe UI Semibold"),
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semibold.woff2') format('woff2'),
          url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semibold.woff') format('woff'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semibold.ttf') format('truetype'),
-         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semibold.svg#SegoeUI-Semibold') format('svg');
+         url('#{$ms-font-directory}/#{$ms-font-path}/SegoeUI-Semibold.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
   }

--- a/src/sass/_Fabric.Typography.Language.Overrides.scss
+++ b/src/sass/_Fabric.Typography.Language.Overrides.scss
@@ -34,14 +34,14 @@
 }
 
 // Base font stack.
-$ms-font-system-base: 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
+$ms-font-system-base: 'Segoe UI', Tahoma, Arial, sans-serif;
 
 // Variables for each of the non-distributed (native) font stacks.
-$ms-font-stack-japanese: YuGothic, "Meiryo UI", Meiryo, "MS Pgothic", Osaka, $ms-font-system-base;
-$ms-font-stack-korean: "Malgun Gothic", Gulim, $ms-font-system-base;
-$ms-font-stack-chinese-simplified: "Microsoft Yahei", Verdana, Simsun, $ms-font-system-base;
-$ms-font-stack-chinese-traditional: "Microsoft Jhenghei", Pmingliu, $ms-font-system-base;
-$ms-font-stack-hindi: "Nirmala UI", $ms-font-system-base;
+$ms-font-stack-japanese: 'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, $ms-font-system-base;
+$ms-font-stack-korean: 'Malgun Gothic', Gulim, $ms-font-system-base;
+$ms-font-stack-chinese-simplified: 'Microsoft Yahei', Verdana, Simsun, $ms-font-system-base;
+$ms-font-stack-chinese-traditional: 'Microsoft Jhenghei', Pmingliu, $ms-font-system-base;
+$ms-font-stack-hindi: 'Nirmala UI', $ms-font-system-base;
 
 
 //== Web fonts

--- a/src/sass/_Fabric.Typography.Variables.scss
+++ b/src/sass/_Fabric.Typography.Variables.scss
@@ -6,10 +6,10 @@
 // Fabric Core Typography variables
 
 
-$ms-font-family-light:     'Segoe UI Light WestEuropean', 'Segoe UI Light', 'Segoe WP Light', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
-$ms-font-family-regular:   'Segoe UI Regular WestEuropean', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
-$ms-font-family-semilight: 'Segoe UI Semilight WestEuropean', 'Segoe UI Semilight', 'Segoe WP Semilight', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
-$ms-font-family-semibold:  'Segoe UI Semibold WestEuropean', 'Segoe UI Semibold', 'Segoe WP Semibold', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
+$ms-font-family-light:     'Segoe UI Light WestEuropean', 'Segoe UI Light', 'Segoe UI', Tahoma, Arial, sans-serif;
+$ms-font-family-regular:   'Segoe UI Regular WestEuropean', 'Segoe UI', Tahoma, Arial, sans-serif;
+$ms-font-family-semilight: 'Segoe UI Semilight WestEuropean', 'Segoe UI Semilight', 'Segoe UI', Tahoma, Arial, sans-serif;
+$ms-font-family-semibold:  'Segoe UI Semibold WestEuropean', 'Segoe UI Semibold', 'Segoe UI', Tahoma, Arial, sans-serif;
 
 
 //== Type sizes


### PR DESCRIPTION
* Updating font face to use local version of Segoe by default
* Adding woff2 Segoe files to the font face
* Removing Segoe WP from the font stacks since Windows Phone now uses standard Segoe
* Referencing Japanese font Yu Gothic properly now (it's Yu Gothic, not YuGothic)