### PR TITLE
Fix issue #67 - Update Dialog component samples

### DIFF
--- a/src/components/Dialog/Dialog.Blocking.html
+++ b/src/components/Dialog/Dialog.Blocking.html
@@ -1,31 +1,30 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<button class="ms-Button js-DialogAction--open" data-target=".ms-Dialog--lgHeader">
+<button class="ms-Button js-DialogAction--open" data-target=".ms-Dialog--blocking">
   <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
-  <span class="ms-Button-label">Open Dialog - Large Header</span>
+  <span class="ms-Button-label">Open Dialog - Blocking</span>
   <span class="ms-Button-description">Opens the Sample Dialog</span>
 </button>
 
-<div class="ms-Dialog ms-Dialog--lgHeader">
-  <div class="ms-Overlay ms-Overlay--dark js-DialogAction--close"></div>
+<div class="ms-Dialog ms-Dialog--blocking">
+  <div class="ms-Overlay"></div>
   <div class="ms-Dialog-main">
     <button class="ms-Dialog-button ms-Dialog-button--close js-DialogAction--close">
       <i class="ms-Icon ms-Icon--x"></i>
     </button>
     <div class="ms-Dialog-header">
-      <p class="ms-Dialog-title">All emails together now</p>
+      <p class="ms-Dialog-title">Unsaved changes</p>
     </div>
     <div class="ms-Dialog-inner">
       <div class="ms-Dialog-content">
-        <p class="ms-Dialog-subText">Your Inbox has changed. No longer does it include favorites, it is a singular destination for your emails.</p>
-      </div>
+        <p class="ms-Dialog-subText">Are you sure you want to discard these changes?</p>
       <div class="ms-Dialog-actions">
         <div class="ms-Dialog-actionsRight">
-          <button class="ms-Dialog-action ms-Button ms-Button--primary">
-            <span class="ms-Button-label">More</span>
-          </button>
           <button class="ms-Dialog-action ms-Button">
-            <span class="ms-Button-label">Got it</span>
+            <span class="ms-Button-label">Yes</span>
+          </button>
+          <button class="ms-Dialog-action ms-Button ms-Button--primary">
+            <span class="ms-Button-label">No</span>
           </button>
         </div>
       </div>

--- a/src/components/Dialog/Dialog.Blocking.html
+++ b/src/components/Dialog/Dialog.Blocking.html
@@ -18,6 +18,7 @@
     <div class="ms-Dialog-inner">
       <div class="ms-Dialog-content">
         <p class="ms-Dialog-subText">Are you sure you want to discard these changes?</p>
+      </div>
       <div class="ms-Dialog-actions">
         <div class="ms-Dialog-actionsRight">
           <button class="ms-Dialog-action ms-Button">

--- a/src/components/Dialog/Dialog.Close.html
+++ b/src/components/Dialog/Dialog.Close.html
@@ -1,9 +1,15 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
+<button class="ms-Button js-DialogAction--open" data-target=".ms-Dialog--close">
+  <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+  <span class="ms-Button-label">Open Dialog - Close</span>
+  <span class="ms-Button-description">Opens the Sample Dialog</span>
+</button>
+
 <div class="ms-Dialog ms-Dialog--close">
-  <div class="ms-Overlay"></div>
+  <div class="ms-Overlay ms-Overlay--dark js-DialogAction--close"></div>
   <div class="ms-Dialog-main">
-    <button class="ms-Dialog-button ms-Dialog-button--close">
+    <button class="ms-Dialog-button ms-Dialog-button--close js-DialogAction--close">
       <i class="ms-Icon ms-Icon--x"></i>
     </button>
     <div class="ms-Dialog-header">

--- a/src/components/Dialog/Dialog.Multiline.html
+++ b/src/components/Dialog/Dialog.Multiline.html
@@ -1,9 +1,15 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
+<button class="ms-Button js-DialogAction--open" data-target=".ms-Dialog--multiline">
+  <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+  <span class="ms-Button-label">Open Dialog - Multiline</span>
+  <span class="ms-Button-description">Opens the Sample Dialog</span>
+</button>
+
 <div class="ms-Dialog ms-Dialog--multiline">
-  <div class="ms-Overlay"></div>
+  <div class="ms-Overlay ms-Overlay--dark ms-DialogAction--close js-DialogAction--close"></div>
   <div class="ms-Dialog-main">
-    <button class="ms-Dialog-button ms-Dialog-button--close">
+    <button class="ms-Dialog-button ms-Dialog-button--close js-DialogAction--close">
       <i class="ms-Icon ms-Icon--x"></i>
     </button>
     <div class="ms-Dialog-header">

--- a/src/components/Dialog/Dialog.html
+++ b/src/components/Dialog/Dialog.html
@@ -1,9 +1,15 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<div class="ms-Dialog">
-  <div class="ms-Overlay"></div>
+<button class="ms-Button js-DialogAction--open" data-target=".ms-Dialog--sample">
+  <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+  <span class="ms-Button-label">Open Dialog</span>
+  <span class="ms-Button-description">Opens the Sample Dialog</span>
+</button>
+
+<div class="ms-Dialog ms-Dialog--sample">
+  <div class="ms-Overlay ms-Overlay--dark js-DialogAction--close"></div>
   <div class="ms-Dialog-main">
-    <button class="ms-Dialog-button ms-Dialog-button--close">
+    <button class="ms-Dialog-button ms-Dialog-button--close js-DialogAction--close">
       <i class="ms-Icon ms-Icon--x"></i>
     </button>
     <div class="ms-Dialog-header">

--- a/src/components/Dialog/Dialog.json
+++ b/src/components/Dialog/Dialog.json
@@ -13,11 +13,13 @@
     "Dialog.html",
     "Dialog.Close.html",
     "Dialog.LgHeader.html",
-    "Dialog.Multiline.html"
+    "Dialog.Multiline.html",
+    "Dialog.Blocking.html"
   ],
   "dependencies": [
     "Button",
-    "ChoiceField"
+    "ChoiceField",
+    "Overlay"
   ],
   "branches": [
     {
@@ -54,6 +56,11 @@
       "name": "Large Header",
       "class": "ms-Dialog--lgHeader",
       "template": "Dialog.LgHeader.html"
+    },
+    {
+      "name": "Blocking",
+      "class": "ms-Dialog--blocking",
+      "template": "Dialog.Blocking.html"
     }
   ]
 }

--- a/src/components/Dialog/jquery.Dialog.js
+++ b/src/components/Dialog/jquery.Dialog.js
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+/**
+ * Dialog Plugin
+ *
+ * Adds basic demonstration functionality to .ms-Dialog components.
+ *
+ * @param  {jQuery Object}  One or more .ms-Dialog components
+ * @return {jQuery Object}  The same components (allows for chaining)
+ */
+(function ($) {
+  $.fn.Dialog = function () {
+
+    /** Iterate through the sample buttons, which can be used to open the Dialogs. */
+    $(".js-DialogAction--open").each(function () {
+        /** Open the associated dialog on click. */
+        $(this).on('click', function () {
+          var target = $(this).data("target");
+          $(target).show();
+        });
+    });
+
+
+    return this.each(function () {
+      var dialog = this;
+
+      /** Have the dialogs hidden for their initial state */
+      $(dialog).hide();
+
+      /** Have the close buttons close the Dialog. */
+      $(dialog).find(".js-DialogAction--close").each(function() {
+        $(this).on('click', function () {
+          $(dialog).hide();
+        });
+      });
+
+      /** Have the action buttons close the Dialog, though you would usually do some specific action per button. */
+      $(dialog).find(".ms-Dialog-action").on('click', function () {
+        $(dialog).hide();
+      });
+
+    });
+  };
+})(jQuery);

--- a/src/components/Panel/Panel.ExtraLarge.html
+++ b/src/components/Panel/Panel.ExtraLarge.html
@@ -1,7 +1,7 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <button class="ms-Button js-togglePanel">
-  <span class="ms-Button-label">Opend panel</span>
+  <span class="ms-Button-label">Open panel</span>
 </button>
 
 <div class="ms-Panel ms-Panel--extraLarge">

--- a/src/components/Panel/Panel.ExtraLarge.html
+++ b/src/components/Panel/Panel.ExtraLarge.html
@@ -1,7 +1,7 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <button class="ms-Button js-togglePanel">
-  <span class="ms-Button-label">Open panel</span>
+  <span class="ms-Button-label">Opend panel</span>
 </button>
 
 <div class="ms-Panel ms-Panel--extraLarge">

--- a/src/templates/componentSampleTemplate.html
+++ b/src/templates/componentSampleTemplate.html
@@ -82,11 +82,6 @@
       margin-bottom: 10px;
     }
 
-    .ms-Dialog {
-      position: relative;
-      margin-bottom: 10px;
-    }
-
     .ms-NavBar-item .ms-ContextualMenu {
       position: absolute;
     }

--- a/src/templates/individual-component-example.html
+++ b/src/templates/individual-component-example.html
@@ -86,11 +86,6 @@
       margin-bottom: 10px;
     }
 
-    .ms-Dialog {
-      position: relative;
-      margin-bottom: 10px;
-    }
-
     .ms-NavBar-item .ms-ContextualMenu {
       position: absolute;
     }


### PR DESCRIPTION
Update Dialog sample to have demonstration JS code for opening and closing. Adjust component sample page so dialogs are modal.  Add additional variant to demonstration different configurations for light closing and blocking dialogs.