### PR TITLE
Change NuGet package's components source folder from "src" to "dist"

### DIFF
--- a/gulp/modules/Config.js
+++ b/gulp/modules/Config.js
@@ -54,7 +54,7 @@ var Config = function() {
 		outputDir: this.paths.distPackages
 	};
 	this.nugetPaths = [
-		{src: this.paths.componentsPath, dest: "/content/components/"},
+		{src: this.paths.distComponents, dest: "/content/components/"},
 		{src: this.paths.distCSS, dest: "/content/css/"},
 		{src: this.paths.distJS, dest: "/content/scripts/"},
 		{src: this.paths.distLess, dest: "/content/less/"},


### PR DESCRIPTION
Previously, NuGet packages were being distributed with a `content/components` folder whose contents came from `src/components`. Instead, it should be populated from `dist/components` like the rest of the package folders.