### PR TITLE
Fixed caret positioning for dropdown with label

### DIFF
--- a/src/components/Dropdown/Dropdown.Disabled.html
+++ b/src/components/Dropdown/Dropdown.Disabled.html
@@ -1,6 +1,7 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <div class="ms-Dropdown is-disabled" tabindex="0">
+  <label class="ms-Label">Dropdown label</label>
   <i class="ms-Dropdown-caretDown ms-Icon ms-Icon--caretDown"></i>
   <select class="ms-Dropdown-select">
     <option>Choose a sound&hellip;</option>

--- a/src/components/Dropdown/Dropdown.html
+++ b/src/components/Dropdown/Dropdown.html
@@ -10,3 +10,16 @@
     <option>Cow mooing</option>
   </select>
 </div>
+
+
+<div class="ms-Dropdown" tabindex="0">
+  <label class="ms-Label">Dropdown label</label>
+  <i class="ms-Dropdown-caretDown ms-Icon ms-Icon--caretDown"></i>
+  <select class="ms-Dropdown-select">
+    <option>Choose a sound&hellip;</option>
+    <option>Dog barking</option>
+    <option>Wind blowing</option>
+    <option>Duck quacking</option>
+    <option>Cow mooing</option>
+  </select>
+</div>

--- a/src/components/Dropdown/Dropdown.html
+++ b/src/components/Dropdown/Dropdown.html
@@ -1,18 +1,6 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <div class="ms-Dropdown" tabindex="0">
-  <i class="ms-Dropdown-caretDown ms-Icon ms-Icon--caretDown"></i>
-  <select class="ms-Dropdown-select">
-    <option>Choose a sound&hellip;</option>
-    <option>Dog barking</option>
-    <option>Wind blowing</option>
-    <option>Duck quacking</option>
-    <option>Cow mooing</option>
-  </select>
-</div>
-
-
-<div class="ms-Dropdown" tabindex="0">
   <label class="ms-Label">Dropdown label</label>
   <i class="ms-Dropdown-caretDown ms-Icon ms-Icon--caretDown"></i>
   <select class="ms-Dropdown-select">

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -69,7 +69,7 @@
   font-size: $ms-font-size-l;
   position: absolute;
   right: 9px;
-  top: 9px;
+  bottom: 5px;
   z-index: 1;
   pointer-events: none;
 }


### PR DESCRIPTION
Fixed the #305 bug with the caret that was not correctly positioned when using a dropdown with a label.

In the following Codepen you can check what had to be changed: http://codepen.io/estruyf/pen/KVxKOY
Here is a Codepen with the whole components css change (only one line): http://codepen.io/estruyf/pen/ZQMYPB