### PR TITLE
Change opened selector for Date Picker

### DIFF
--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -56,7 +56,7 @@
 }
 
 // When a picker opens, always open it in front of other closed pickers
-.ms-DatePicker-picker--focused.ms-DatePicker-picker--opened { 
+.ms-DatePicker-picker--opened { 
   position: relative; 
   z-index: $ms-zIndex-front; 
 }


### PR DESCRIPTION
The focused state has been removed in newer versions of Pickadate. This changes the CSS to target only the opened state. Fixes #336.