### PR TITLE
Fix toggle label position.

### DIFF
--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -20,8 +20,7 @@
   // Action label (on/off) on the right of the toggle
   .ms-Label {
     position: relative;
-    padding-left: 62px;
-    top: -2px;
+    padding: 0 0 0 62px;
     font-size: $ms-font-size-s;
   }
 


### PR DESCRIPTION
Fixes #343 

Here's what the label looks like with this fix:

![image](https://cloud.githubusercontent.com/assets/1382445/12963418/354f06a0-cfff-11e5-8154-5210c1660528.png)
