### PR TITLE
Fix for persona circle overflow bug when animating.

### DIFF
--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -40,6 +40,7 @@ $ms-color-initials-darkRed: 		#b91d47;
 	width: 48px;
 	height: 48px;
 	border-radius: 50%;
+	z-index: 0;
 }
 
 //= Note: The doughboy placeholder is being deprecated.

--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -40,7 +40,7 @@ $ms-color-initials-darkRed: 		#b91d47;
 	width: 48px;
 	height: 48px;
 	border-radius: 50%;
-	z-index: 0;
+	z-index: $ms-zIndex-back;
 }
 
 //= Note: The doughboy placeholder is being deprecated.


### PR DESCRIPTION
In Chrome circle personas were briefly losing the circle effect during animations.