### PR TITLE
Updating ListItem's tertiary text so that descenders aren't obscured

### DIFF
--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -45,9 +45,9 @@
   color: $ms-color-neutralSecondaryAlt;
   font-family: $ms-font-family-semilight;
   font-size: $ms-font-size-m;
-  line-height: 15px;
   position: relative;
-  top: -7px;
+  top: -9px;
+  margin-bottom: -4px;
   padding-right: 30px;
 }
 


### PR DESCRIPTION
Removing line-height and adding negative margins to not obscure the descenders.

Fixes https://github.com/OfficeDev/Office-UI-Fabric/issues/174