### PR TITLE
Allow table markup to be used to render Fabric table

### DIFF
--- a/src/components/Table/Table.html
+++ b/src/components/Table/Table.html
@@ -1,50 +1,43 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<table class="ms-Table">
-  <thead class="ms-Table-head">
-    <tr class="ms-Table-row">
+<table>
+  <thead>
+    <tr>
       <th class="ms-Table-rowCheck"></th>
-      <th class="ms-Table-cell">File name</th>
-      <th class="ms-Table-cell">Location</th>
-      <th class="ms-Table-cell">Modified</th>
-      <th class="ms-Table-cell">Type</th>
+      <th>File name</th>
+      <th>Location</th>
+      <th>Modified</th>
+      <th>Type</th>
     </tr>
   </thead>
   <tbody>
-    <tr class="ms-Table-row">
+    <tr>
       <td class="ms-Table-rowCheck"></td>
-      <td class="ms-Table-cell">File name</td>
-      <td class="ms-Table-cell">Location</td>
-      <td class="ms-Table-cell">Modified</td>
-      <td class="ms-Table-cell">Type</td>
+      <td>File name</td>
+      <td>Location</td>
+      <td>Modified</td>
+      <td>Type</td>
     </tr>
-    <tr class="ms-Table-row">
+    <tr>
       <td class="ms-Table-rowCheck"></td>
-      <td class="ms-Table-cell">File name</td>
-      <td class="ms-Table-cell">Location</td>
-      <td class="ms-Table-cell">Modified</td>
-      <td class="ms-Table-cell">Type</td>
+      <td>File name</td>
+      <td>Location</td>
+      <td>Modified</td>
+      <td>Type</td>
     </tr>
-    <tr class="ms-Table-row is-selected">
+    <tr>
       <td class="ms-Table-rowCheck"></td>
-      <td class="ms-Table-cell">File name</td>
-      <td class="ms-Table-cell">Location</td>
-      <td class="ms-Table-cell">Modified</td>
-      <td class="ms-Table-cell">Type</td>
+      <td>File name</td>
+      <td>Location</td>
+      <td>Modified</td>
+      <td>Type</td>
     </tr>
-    <tr class="ms-Table-row">
+    <tr>
       <td class="ms-Table-rowCheck"></td>
-      <td class="ms-Table-cell">File name</td>
-      <td class="ms-Table-cell">Location</td>
-      <td class="ms-Table-cell">Modified</td>
-      <td class="ms-Table-cell">Type</td>
-    </tr>
-    <tr class="ms-Table-row">
-      <td class="ms-Table-rowCheck"></td>
-      <td class="ms-Table-cell">File name</td>
-      <td class="ms-Table-cell">Location</td>
-      <td class="ms-Table-cell">Modified</td>
-      <td class="ms-Table-cell">Type</td>
+      <td>File name</td>
+      <td>Location</td>
+      <td>Modified</td>
+      <td>Type</td>
     </tr>
   </tbody>
 </table>

--- a/src/components/Table/Table.html
+++ b/src/components/Table/Table.html
@@ -1,46 +1,50 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<div class="ms-Table">
-  <div class="ms-Table-row">
-    <span class="ms-Table-rowCheck"></span>
-    <span class="ms-Table-cell">File name</span>
-    <span class="ms-Table-cell">Location</span>
-    <span class="ms-Table-cell">Modified</span>
-    <span class="ms-Table-cell">Type</span>
-  </div>
-  <div class="ms-Table-row">
-    <span class="ms-Table-rowCheck"></span>
-    <span class="ms-Table-cell">File name</span>
-    <span class="ms-Table-cell">Location</span>
-    <span class="ms-Table-cell">Modified</span>
-    <span class="ms-Table-cell">Type</span>
-  </div>
-  <div class="ms-Table-row">
-    <span class="ms-Table-rowCheck"></span>
-    <span class="ms-Table-cell">File name</span>
-    <span class="ms-Table-cell">Location</span>
-    <span class="ms-Table-cell">Modified</span>
-    <span class="ms-Table-cell">Type</span>
-  </div>
-  <div class="ms-Table-row is-selected">
-    <span class="ms-Table-rowCheck"></span>
-    <span class="ms-Table-cell">File name</span>
-    <span class="ms-Table-cell">Location</span>
-    <span class="ms-Table-cell">Modified</span>
-    <span class="ms-Table-cell">Type</span>
-  </div>
-  <div class="ms-Table-row">
-    <span class="ms-Table-rowCheck"></span>
-    <span class="ms-Table-cell">File name</span>
-    <span class="ms-Table-cell">Location</span>
-    <span class="ms-Table-cell">Modified</span>
-    <span class="ms-Table-cell">Type</span>
-  </div>
-  <div class="ms-Table-row">
-    <span class="ms-Table-rowCheck"></span>
-    <span class="ms-Table-cell">File name</span>
-    <span class="ms-Table-cell">Location</span>
-    <span class="ms-Table-cell">Modified</span>
-    <span class="ms-Table-cell">Type</span>
-  </div>
-</div>
+<table class="ms-Table">
+  <thead class="ms-Table-head">
+    <tr class="ms-Table-row">
+      <th class="ms-Table-rowCheck"></th>
+      <th class="ms-Table-cell">File name</th>
+      <th class="ms-Table-cell">Location</th>
+      <th class="ms-Table-cell">Modified</th>
+      <th class="ms-Table-cell">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="ms-Table-row">
+      <td class="ms-Table-rowCheck"></td>
+      <td class="ms-Table-cell">File name</td>
+      <td class="ms-Table-cell">Location</td>
+      <td class="ms-Table-cell">Modified</td>
+      <td class="ms-Table-cell">Type</td>
+    </tr>
+    <tr class="ms-Table-row">
+      <td class="ms-Table-rowCheck"></td>
+      <td class="ms-Table-cell">File name</td>
+      <td class="ms-Table-cell">Location</td>
+      <td class="ms-Table-cell">Modified</td>
+      <td class="ms-Table-cell">Type</td>
+    </tr>
+    <tr class="ms-Table-row is-selected">
+      <td class="ms-Table-rowCheck"></td>
+      <td class="ms-Table-cell">File name</td>
+      <td class="ms-Table-cell">Location</td>
+      <td class="ms-Table-cell">Modified</td>
+      <td class="ms-Table-cell">Type</td>
+    </tr>
+    <tr class="ms-Table-row">
+      <td class="ms-Table-rowCheck"></td>
+      <td class="ms-Table-cell">File name</td>
+      <td class="ms-Table-cell">Location</td>
+      <td class="ms-Table-cell">Modified</td>
+      <td class="ms-Table-cell">Type</td>
+    </tr>
+    <tr class="ms-Table-row">
+      <td class="ms-Table-rowCheck"></td>
+      <td class="ms-Table-cell">File name</td>
+      <td class="ms-Table-cell">Location</td>
+      <td class="ms-Table-cell">Modified</td>
+      <td class="ms-Table-cell">Type</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/components/Table/Table.html
+++ b/src/components/Table/Table.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<table>
+<table class="ms-Table">
   <thead>
     <tr>
       <th class="ms-Table-rowCheck"></th>

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -5,14 +5,13 @@
 // --------------------------------------------------
 // Data table styles
 
-table,
 .ms-Table {
   display: table;
   width: 100%;
   border-collapse: collapse;
 }
 
-tr,
+.ms-Table tr,
 .ms-Table-row {
   display: table-row;
   height: 30px;
@@ -54,23 +53,23 @@ tr,
   }
 }
 
-th,
-td,
+.ms-Table th,
+.ms-Table td,
 .ms-Table-cell {
   display: table-cell;
   padding: 0 10px;
 }
 
 // Style the first row as a header.
-thead td,
-thead th,
+.ms-Table thead td,
+.ms-Table thead th,
 .ms-Table-head {
   font-family: $ms-font-family-semilight;
   font-size: $ms-font-size-xs;
   color: $ms-color-neutralSecondary;
 }
 
-thead,
+.ms-Table thead,
 .ms-Table-head {
   
   td,
@@ -94,7 +93,7 @@ thead,
 }
 
 // On selectable tables, each row has a checkbox.
-.ms-Table-rowCheck {
+.ms-Table .ms-Table-rowCheck {
   display: table-cell;
   width: 20px;
   position: relative;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -61,7 +61,6 @@
 }
 
 // Style the first row as a header.
-.ms-Table thead td,
 .ms-Table thead th,
 .ms-Table-head {
   font-family: $ms-font-family-semilight;
@@ -93,7 +92,7 @@
 }
 
 // On selectable tables, each row has a checkbox.
-.ms-Table .ms-Table-rowCheck {
+.ms-Table-rowCheck {
   display: table-cell;
   width: 20px;
   position: relative;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -9,6 +9,7 @@
 .ms-Table {
   display: table;
   width: 100%;
+  border-collapse: collapse;
 }
 
 .ms-Table-row {
@@ -58,12 +59,15 @@
 }
 
 // Style the first row as a header.
-.ms-Table-row:first-child {
+.ms-Table-head {
   font-family: $ms-font-family-semilight;
   font-size: $ms-font-size-xs;
   color: $ms-color-neutralSecondary;
 
-  .ms-Table-cell, .ms-Table-rowCheck {
+  .ms-Table-cell, 
+  .ms-Table-rowCheck {
+    font-weight: normal;
+    text-align: left;
     border-bottom: 1px solid $ms-color-neutralLight;
   }
 

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -14,7 +14,6 @@
 .ms-Table tr,
 .ms-Table-row {
   display: table-row;
-  height: 30px;
   line-height: 30px;
   font-family: $ms-font-family-semilight;
   font-size: $ms-font-size-s;
@@ -70,10 +69,9 @@
 
 .ms-Table thead,
 .ms-Table-head {
-  
   td,
   th,
-  .ms-Table-cell, 
+  .ms-Table-cell,
   .ms-Table-rowCheck {
     font-weight: normal;
     text-align: left;
@@ -97,7 +95,7 @@
   width: 20px;
   position: relative;
   padding: 0;
-  
+
   // Empty checkbox.
   &:before {
     border: 1px solid $ms-color-neutralTertiary;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -5,13 +5,14 @@
 // --------------------------------------------------
 // Data table styles
 
-
+table,
 .ms-Table {
   display: table;
   width: 100%;
   border-collapse: collapse;
 }
 
+tr,
 .ms-Table-row {
   display: table-row;
   height: 30px;
@@ -53,17 +54,27 @@
   }
 }
 
+th,
+td,
 .ms-Table-cell {
   display: table-cell;
   padding: 0 10px;
 }
 
 // Style the first row as a header.
+thead td,
+thead th,
 .ms-Table-head {
   font-family: $ms-font-family-semilight;
   font-size: $ms-font-size-xs;
   color: $ms-color-neutralSecondary;
+}
 
+thead,
+.ms-Table-head {
+  
+  td,
+  th,
   .ms-Table-cell, 
   .ms-Table-rowCheck {
     font-weight: normal;
@@ -87,7 +98,8 @@
   display: table-cell;
   width: 20px;
   position: relative;
-
+  padding: 0;
+  
   // Empty checkbox.
   &:before {
     border: 1px solid $ms-color-neutralTertiary;


### PR DESCRIPTION
Looks like the biggest difference between the table structure and the current implementation is the border-collapse property needs to be set for tables.
Converting sample markup from divs to tables.

Note: leaving 'display: table' and 'display: table-cell' properties so that users can choose tables or divs.  

Fixes: https://github.com/OfficeDev/Office-UI-Fabric/issues/192