### PR TITLE
Issue #371, plus other enhancements/cleanup to PersonaCard

### DIFF
--- a/src/components/PersonaCard/Jquery.PersonaCard.js
+++ b/src/components/PersonaCard/Jquery.PersonaCard.js
@@ -8,50 +8,62 @@
  * @param  {jQuery Object}  One or more .ms-PersonaCard components
  * @return {jQuery Object}  The same components (allows for chaining)
  */
-(function ($) {
-  $.fn.PersonaCard = function () {
+(function ($) {    
+    /* Show/Hide the appropriate details for the selected Action */
+    function toggleDetails(target){		
+        if('undefined' === typeof target){
+            var targetIds = [];
+            $('.ms-PersonaCard-action.is-active').each(function(){
+                target = $(this).attr('data-detailsTargetId');
+		        if('undefined' !== typeof target){
+                    targetIds.push(target);
+                }
+            });
+            targetIds.forEach(toggleDetails);
+        }
+        else{
+            var actionUrl = $("li[data-detailsTargetId='" + target + "']").attr('data-actionUrl');
+            if("undefined" === typeof actionUrl){
+                $('#' + target).parent().children().removeClass('is-active').hide();
+		        $('#' + target).addClass('is-active').show();
+            }
+            else{
+                document.location.href=actionUrl;
+            }
+        }
+	}    
+  
+    $.fn.PersonaCard = function () {
+    toggleDetails();
 
-    /** Go through each file picker we've been given. */
+    /** Go through each PersonaCard  we've been given. */
     return this.each(function () {
 
       var $personaCard = $(this);
 
-      /** When selecting an action, show its details. */
-      $personaCard.on('click', '.ms-PersonaCard-action', function() {
+      /** Register action click handler */
+      $personaCard.on('click', '.ms-PersonaCard-action', handleActionClick);
+      $personaCard.on('click', '.ms-PersonaCard-overflow', handleActionClick);
+      
+      /** When clicking an action, show its details. */
+      function handleActionClick() {
 
         /** Select the correct tab. */
         $personaCard.find('.ms-PersonaCard-action').removeClass('is-active');
         $(this).addClass('is-active');
-
-        /** Function for switching selected item into view by adding a class to ul. */
-        var updateForItem = function(wrapper, item) {
-          var previousItem = wrapper.className + "";
-          var detail = item.charAt(0).toUpperCase() + item.slice(1);
-          var nextItem = "ms-PersonaCard-detail" + detail;
-          if (previousItem !== nextItem){
-            wrapper.classList.remove(previousItem);
-            wrapper.classList.add(nextItem);
-          }
-        };
-
-        /** Get id of selected item */
-        var el = $(this).attr('id');
-        /** Add detail class to ul to switch it into view. */
-        updateForItem($(this).parent().next().find('#detailList')[0], el);
-
-        /** Display the corresponding details. */
-        var requestedAction = $(this).attr('id');
-        $personaCard.find('.ms-PersonaCard-actionDetails').removeClass('is-active');
-        $personaCard.find('#' + requestedAction + '.ms-PersonaCard-actionDetails').addClass('is-active');
-
-      });
-
+        var target = $(this).attr('data-detailsTargetId');
+        toggleDetails(target);        
+      }
+      
       /** Toggle more details. */
+      /** --(DM) NOT USED?   */
       $personaCard.on('click', '.ms-PersonaCard-detailExpander', function() {
         $(this).parent('.ms-PersonaCard-actionDetails').toggleClass('is-collapsed');
       });
 
     });
 
+      
+    
   };
 })(jQuery);

--- a/src/components/PersonaCard/PersonaCard.Square.html
+++ b/src/components/PersonaCard/PersonaCard.Square.html
@@ -15,31 +15,39 @@
     </div>
   </div>
   <ul class="ms-PersonaCard-actions">
-    <li id="chat" class="ms-PersonaCard-action is-active"><i class="ms-Icon ms-Icon--chat"></i></li>
-    <li id="phone" class="ms-PersonaCard-action"><i class="ms-Icon ms-Icon--phone"></i></li>
-    <li id="video" class="ms-PersonaCard-action"><i class="ms-Icon ms-Icon--video"></i></li>
-    <li id="mail" class="ms-PersonaCard-action"><i class="ms-Icon ms-Icon--mail"></i></li>
-    <li class="ms-PersonaCard-overflow" alt="View profile in Delve" title="View profile in Delve">View profile</li>
-    <li id="org" class="ms-PersonaCard-action ms-PersonaCard-orgChart"><i class="ms-Icon ms-Icon--org"></i></li>
+    <li id="phoneAction" class="ms-PersonaCard-action" data-detailsTargetId="detail-2b"><i class="ms-Icon ms-Icon--phone"></i></li>
+    <li id="chatAction" class="ms-PersonaCard-action" data-detailsTargetId="detail-1b"><i class="ms-Icon ms-Icon--chat"></i></li>
+    <li id="videoAction" class="ms-PersonaCard-action" data-detailsTargetId="detail-3b"><i class="ms-Icon ms-Icon--video"></i></li>
+    <li id="mailAction" class="ms-PersonaCard-action is-active" data-detailsTargetId="detail-4b"><i class="ms-Icon ms-Icon--mail"></i></li>
+    <li id="profileAction" class="ms-PersonaCard-overflow" data-detailsTargetId="detail-5b" data-actionUrl="http://dev.office.com/fabric" alt="View profile in Delve" title="View profile in Delve">View profile</li>
+    <li id="orgAction" class="ms-PersonaCard-action ms-PersonaCard-orgChart" data-detailsTargetId="detail-6b"><i class="ms-Icon ms-Icon--org"></i></li>
   </ul>
   <div class="ms-PersonaCard-actionDetailBox">
-    <ul id="detailList" class="ms-PersonaCard-detailChat">
-      <li id="chat" class="ms-PersonaCard-actionDetails detail-1">
+    <ul id="detail-1b" class="ms-PersonaCard-details">
+      <li  class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Lync:</span> <a class="ms-Link" href="#">Start Lync call</a></div>
       </li>
-      <li id="phone" class="ms-PersonaCard-actionDetails detail-2">
+   </ul>
+   <ul id="detail-2b" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Personal:</span> 555.206.2443</div>
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Work:</span> 555.929.8240</div>
       </li>
-      <li id="video" class="ms-PersonaCard-actionDetails detail-3">
+   </ul>
+   <ul id="detail-3b" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Skype:</span> <a class="ms-Link" href="#">Start Skype call</a></div>
       </li>
-      <li id="mail" class="ms-PersonaCard-actionDetails detail-4">
+   </ul>
+   <ul id="detail-4b" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Personal:</span> <a class="ms-Link" href="mailto:alton.lafferty@outlook.com">alton.lafferty@outlook.com</a></div>
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Work:</span> <a class="ms-Link" href="mailto:alton.lafferty@outlook.com">altonlafferty@contoso.com</a></div>
       </li>
+   </ul>
       <!-- org chart -->
-      <li id="org" class="ms-PersonaCard-actionDetails detail-5">
+   <ul id="detail-6b" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails>
         <div class="ms-OrgChart">
           <div class="ms-OrgChart-group">
               <ul class="ms-OrgChart-list">

--- a/src/components/PersonaCard/PersonaCard.html
+++ b/src/components/PersonaCard/PersonaCard.html
@@ -17,31 +17,39 @@
     </div>
   </div>
   <ul class="ms-PersonaCard-actions">
-    <li id="chat" class="ms-PersonaCard-action is-active"><i class="ms-Icon ms-Icon--chat"></i></li>
-    <li id="phone" class="ms-PersonaCard-action"><i class="ms-Icon ms-Icon--phone"></i></li>
-    <li id="video" class="ms-PersonaCard-action"><i class="ms-Icon ms-Icon--video"></i></li>
-    <li id="mail" class="ms-PersonaCard-action"><i class="ms-Icon ms-Icon--mail"></i></li>
-    <li class="ms-PersonaCard-overflow" alt="View profile in Delve" title="View profile in Delve">View profile</li>
-    <li id="org" class="ms-PersonaCard-action ms-PersonaCard-orgChart"><i class="ms-Icon ms-Icon--org"></i></li>
+    <li id="phoneAction" class="ms-PersonaCard-action" data-detailsTargetId="detail-2"><i class="ms-Icon ms-Icon--phone"></i></li>
+    <li id="chatAction" class="ms-PersonaCard-action is-active" data-detailsTargetId="detail-1"><i class="ms-Icon ms-Icon--chat"></i></li>
+    <li id="videoAction" class="ms-PersonaCard-action" data-detailsTargetId="detail-3"><i class="ms-Icon ms-Icon--video"></i></li>
+    <li id="mailAction" class="ms-PersonaCard-action" data-detailsTargetId="detail-4"><i class="ms-Icon ms-Icon--mail"></i></li>
+    <li id="profileAction" class="ms-PersonaCard-overflow" data-detailsTargetId="detail-5" data-actionUrl="http://dev.office.com/fabric" alt="View profile in Delve" title="View profile in Delve">View profile</li>
+    <li id="orgAction" class="ms-PersonaCard-action ms-PersonaCard-orgChart" data-detailsTargetId="detail-6"><i class="ms-Icon ms-Icon--org"></i></li>
   </ul>
   <div class="ms-PersonaCard-actionDetailBox">
-    <ul id="detailList" class="ms-PersonaCard-detailChat">
-      <li id="chat" class="ms-PersonaCard-actionDetails detail-1">
+    <ul id="detail-1" class="ms-PersonaCard-details">
+      <li  class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Lync:</span> <a class="ms-Link" href="#">Start Lync call</a></div>
       </li>
-      <li id="phone" class="ms-PersonaCard-actionDetails detail-2">
+   </ul>
+   <ul id="detail-2" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Personal:</span> 555.206.2443</div>
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Work:</span> 555.929.8240</div>
       </li>
-      <li id="video" class="ms-PersonaCard-actionDetails detail-3">
+   </ul>
+   <ul id="detail-3" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Skype:</span> <a class="ms-Link" href="#">Start Skype call</a></div>
       </li>
-      <li id="mail" class="ms-PersonaCard-actionDetails detail-4">
+   </ul>
+   <ul id="detail-4" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails">
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Personal:</span> <a class="ms-Link" href="mailto:alton.lafferty@outlook.com">alton.lafferty@outlook.com</a></div>
         <div class="ms-PersonaCard-detailLine"><span class="ms-PersonaCard-detailLabel">Work:</span> <a class="ms-Link" href="mailto:alton.lafferty@outlook.com">altonlafferty@contoso.com</a></div>
       </li>
+   </ul>
       <!-- org chart -->
-      <li id="org" class="ms-PersonaCard-actionDetails detail-5">
+   <ul id="detail-6" class="ms-PersonaCard-details">
+      <li class="ms-PersonaCard-actionDetails>
         <div class="ms-OrgChart">
           <div class="ms-OrgChart-group">
               <ul class="ms-OrgChart-list">

--- a/src/components/PersonaCard/PersonaCard.scss
+++ b/src/components/PersonaCard/PersonaCard.scss
@@ -158,17 +158,14 @@
 }
 
 // Active detail items
-.ms-PersonaCard-detailChat,
-.ms-PersonaCard-detailPhone,
-.ms-PersonaCard-detailVideo,
-.ms-PersonaCard-detailMail,
-.ms-PersonaCard-detailOrg {
+.ms-PersonaCard-details {
   overflow: hidden;
   width: 500%;
   padding: 0;
   margin: 0;
 }
 
+/*
 .ms-PersonaCard-detailOrg {
   overflow-y: auto;
 }
@@ -188,20 +185,22 @@
 .ms-PersonaCard-detailOrg {
   margin-left: -400%;
 }
+*/
 
-.ms-PersonaCard-detailChat .detail-1,
-.ms-PersonaCard-detailPhone .detail-2,
-.ms-PersonaCard-detailVideo .detail-3,
-.ms-PersonaCard-detailMail .detail-4 {
+#detail-1,
+#detail-2,
+#detail-3,
+#detail-4 {
   max-height: 78px;
   transition: max-height 0.25s ease;
 }
 
-.ms-PersonaCard-detailOrg .detail-5 {
+#detail-5 {
   max-height: 300px;
   transition: max-height 0.25s ease;
 }
 
+/*
 // Inactive Items
 .ms-PersonaCard-detailChat .detail-2,
 .ms-PersonaCard-detailChat .detail-3,
@@ -225,6 +224,8 @@
 .ms-PersonaCard-detailOrg .detail-4 {
   max-height: 48px;
 }
+
+*/
 
 // Icon to expand a collapsed actionDetails section.
 .ms-PersonaCard-detailExpander {


### PR DESCRIPTION
Updates to PersonaCard.  Bug #371 plus:

1. Order of actions `<li>` and detail sections in the HTML are now irrelevant.  Action has an attribute 'data-datailsTargetId' which must match the id of the target `<ul>`
2. Whichever action has the 'is-active' attribute will be set to visible on initial load
3. JS no longer tied to specific class names in CSS for which action/details to show (no need to change CSS if changing actions)
4. Made sure it works with multiple cards on a page (so long as IDs are unique)
5. Cleaned up CSS, JS and HTML
6. Added support for actions to navigate to new pages via data-actionUrl attribute (i.e. for "View Profile" action.)