### PR TITLE
Update NuGet package structure to conform with other Office packages

### DIFF
--- a/gulp/modules/Config.js
+++ b/gulp/modules/Config.js
@@ -52,9 +52,9 @@ var Config = function() {
 		outputDir: this.paths.distPackages
 	};
 	this.nugetPaths = [
-		{src: this.paths.distCSS, dest: "/content/"},
-		{src: this.paths.distSass, dest: "/content/sass/"},
-		{src: this.paths.distJS, dest: "/scripts/"}
+		{src: this.paths.distCSS, dest: "/content/Content/"},
+		{src: this.paths.distSass, dest: "/content/Content/sass/"},
+		{src: this.paths.distJS, dest: "/content/Scripts/"}
 	];
   this.componentSamplesUpdate = "Components Samples updated successfully! Yay!";
   this.componentSamplesFinished = ' Component Samples build was successful! Yay!';


### PR DESCRIPTION
This PR brings the order and capitalisation of the Content and Scripts folder in line with other, similar NuGet packages, such as Office.js