### PR TITLE
Removes 'href' attribute from sample

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.html
+++ b/src/components/Breadcrumb/Breadcrumb.html
@@ -10,27 +10,27 @@
   </div>
   <ul class="ms-Breadcrumb-list">
     <li class="ms-Breadcrumb-listItem">
-      <a class="ms-Breadcrumb-itemLink" href="#" tabindex="2">Files</a>
+      <a class="ms-Breadcrumb-itemLink" tabindex="2">Files</a>
       <i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>
     </li>
     <li class="ms-Breadcrumb-listItem">
-      <a class="ms-Breadcrumb-itemLink" href="#" tabindex="3">Folder 1</a>
+      <a class="ms-Breadcrumb-itemLink" tabindex="3">Folder 1</a>
       <i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>
     </li>
     <li class="ms-Breadcrumb-listItem">
-      <a class="ms-Breadcrumb-itemLink" href="#" tabindex="4">Folder 2</a>
+      <a class="ms-Breadcrumb-itemLink" tabindex="4">Folder 2</a>
       <i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>
     </li>
     <li class="ms-Breadcrumb-listItem">
-      <a class="ms-Breadcrumb-itemLink" href="#" tabindex="5">Folder 3</a>
+      <a class="ms-Breadcrumb-itemLink" tabindex="5">Folder 3</a>
       <i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>
     </li>
     <li class="ms-Breadcrumb-listItem">
-      <a class="ms-Breadcrumb-itemLink" href="#" tabindex="6">Folder 4</a>
+      <a class="ms-Breadcrumb-itemLink" tabindex="6">Folder 4</a>
       <i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>
     </li>
     <li class="ms-Breadcrumb-listItem">
-      <a class="ms-Breadcrumb-itemLink" href="#" tabindex="7">Folder 5</a>
+      <a class="ms-Breadcrumb-itemLink" tabindex="7">Folder 5</a>
       <i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>
     </li>
   </ul>

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -104,7 +104,9 @@ fabric.Breadcrumb.prototype = (function() {
       }
       var a = document.createElement('a');
       a.className = 'ms-ContextualMenu-link';
-      a.setAttribute('href', item.link);
+      if (item.link !== null) {
+        a.setAttribute('href', item.link);
+      }
       a.textContent = item.text;
       li.appendChild(a);
       _contextMenu.appendChild(li);
@@ -126,7 +128,9 @@ fabric.Breadcrumb.prototype = (function() {
         var chevron = document.createElement('i');
         listItem.className = 'ms-Breadcrumb-listItem';
         a.className = 'ms-Breadcrumb-itemLink';
-        a.setAttribute('href', item.link);
+        if (item.link !== null) {
+            a.setAttribute('href', item.link);
+        }
         if(!isNaN(item.tabIndex)) {
           a.setAttribute('tabindex', item.tabIndex);
         }

--- a/src/components/Breadcrumb/Breadcrumb.scss
+++ b/src/components/Breadcrumb/Breadcrumb.scss
@@ -104,6 +104,7 @@
 
   &:hover {
     background-color: $ms-color-neutralLighter;
+    cursor: pointer;
   }
 
   &:focus {


### PR DESCRIPTION
Fixes #379.

Removes the 'href' attribute from samples to prevent unwanted scrolling when clicking a breadcrumb item. Updates the JS to only add the 'href' attribute to generated links if a value was provided. Ensures that the cursor is a pointer on hover.