### PR TITLE
Remove the hero link variant

### DIFF
--- a/src/components/Link/Link.Hero.html
+++ b/src/components/Link/Link.Hero.html
@@ -1,5 +1,0 @@
-<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
-
-<div class="ms-font-m">
-  <a href="#" class="ms-Link ms-Link--hero">Link to a webpage</a>
-</div>

--- a/src/components/Link/Link.html
+++ b/src/components/Link/Link.html
@@ -1,5 +1,6 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<div class="ms-font-m">
-  <a href="#" class="ms-Link">Link to a webpage</a>
-</div>
+<p class="ms-font-xxl">You can add <a class="ms-Link">links</a> to any text</p>
+<p class="ms-font-m">
+  Lorem ipsum dolor sit amet, <a class="ms-Link">consectetur adipiscing elit</a>. In condimentum nisl sed dolor consectetur, vitae hendrerit nulla ullamcorper. Sed quis massa mi. Etiam sed ullamcorper est. Phasellus sodales tempus sapien et tristique. Praesent non mauris sem. Aliquam leo elit, molestie sed eros ac, sodales mattis metus. Cras <a class="ms-Link">imperdiet</a> est vel quam faucibus posuere. Praesent quis felis mattis, dapibus nibh ut, porttitor dui. Curabitur in eleifend tortor, vel fermentum enim. Etiam blandit quam neque, quis pretium lorem finibus pharetra. Aliquam a placerat arcu. Sed at nibh et nulla ullamcorper pharetra ac ac tortor. Nullam arcu justo, vulputate et efficitur ut, finibus sit amet leo. Phasellus non sem id sapien <a class="ms-Link">gravida sodales</a> et at leo.
+</p>

--- a/src/components/Link/Link.json
+++ b/src/components/Link/Link.json
@@ -4,15 +4,9 @@
   "description": "A component containing styles for links including two variants.",
   "template": "Link.html",
   "class": "ms-Link",
-  "wrapBranches": true,
-  "fileOrder": [
-    "Link.html",
-    "Link.Hero.html"
-  ],
   "branches": [
     {
-      "name": "Hero",
-      "class": "ms-Link--hero",
+      "name": "Default",
       "default": true
     }
   ]

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -24,10 +24,3 @@
 .ms-Link {
   @include ms-Link;
 }
-
-//== Modifier: Hero Links
-//
-.ms-Link.ms-Link--hero {
-  font-family: $ms-font-family-semilight;
-  padding: 2px 8px 4px;
-}


### PR DESCRIPTION
Fixes #338.

Removes the hero link variant. Also adds a heading and paragraph of text to the sample, demonstrating how links can be added to any text.