### PR TITLE
Adds a dependency on Label to Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.json
+++ b/src/components/Dropdown/Dropdown.json
@@ -4,6 +4,9 @@
   "description": "The styling for a dropdown component and its disabled variant. This dropdown takes current items in a real HTML dropdown and creates a shimmed version that can be styled and selected.",
   "template": "Dropdown.html",
   "class": "ms-Dropdown",
+  "dependencies": [
+    "Label"
+  ],
   "fileOrder": [
     "Dropdown.html",
     "Dropdown.Disabled.html"


### PR DESCRIPTION
Dropdown was missing a dependency for Label.

Before this change:
![screen shot 2016-03-04 at 7 19 31 am](https://cloud.githubusercontent.com/assets/1382445/13531134/c644aa3e-e1d9-11e5-8dd0-57799e322191.png)

After:
![screen shot 2016-03-04 at 7 20 45 am](https://cloud.githubusercontent.com/assets/1382445/13531135/c7658244-e1d9-11e5-836b-7d85c174752b.png)
