### PR TITLE
Add Facepile component back to Fabric components

### DIFF
--- a/src/sass/Fabric.Components.scss
+++ b/src/sass/Fabric.Components.scss
@@ -9,6 +9,7 @@
 @import '../components/DatePicker/DatePicker';
 @import '../components/Dialog/Dialog';
 @import '../components/Dropdown/Dropdown';
+@import '../components/Facepile/Facepile';
 @import '../components/Label/Label';
 @import '../components/Link/Link';
 @import '../components/List/List';


### PR DESCRIPTION
This adds Facepile back into Fabric's main output. Fixes #411 