### PR TITLE
Sets a max-height on the dropdown list items

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -97,6 +97,7 @@
   list-style-type: none;
   position: absolute;
   width: 100%;
+  max-height: 200px;
   max-width: 268px;
   z-index: ($ms-zIndex-Dropdown + $ms-zIndex-back);
   top: 0;


### PR DESCRIPTION
This causes it to scroll if the list has more than 5 items.

Fixes #329.