### PR TITLE
Fix #424, spinner no longer speeds up when restarted

### DIFF
--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -34,6 +34,7 @@ fabric.Spinner = function(target) {
      * @memberOf fabric.Spinner
      */
     function start() {
+        clearInterval(interval);
         interval = setInterval(function() {
             var i = circleObjects.length;
             while(i--) {

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -34,7 +34,7 @@ fabric.Spinner = function(target) {
      * @memberOf fabric.Spinner
      */
     function start() {
-        clearInterval(interval);
+        stop();
         interval = setInterval(function() {
             var i = circleObjects.length;
             while(i--) {


### PR DESCRIPTION
If `setInterval` is called multiple times then there will be multiple intervals animating the spinner, which makes it look faster

Added clearInterval, to clear the previous interval