### PR TITLE
Added pivot functionality similar to Bootstrap tabs

### DIFF
--- a/src/components/Pivot/Pivot.Large.html
+++ b/src/components/Pivot/Pivot.Large.html
@@ -1,10 +1,37 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <ul class="ms-Pivot ms-Pivot--large">
-  <li class="ms-Pivot-link is-selected">My files</li>
-  <li class="ms-Pivot-link">Recent</li>
-  <li class="ms-Pivot-link">Shared with me</li>
-  <li class="ms-Pivot-link ms-Pivot-link--overflow">
-    <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
-  </li>
+    <li class="ms-Pivot-link is-selected" data-pivotContent="[data-demo='large']>.files">My files</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='large']>.recent">Recent</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='large']>.shared">Shared with me</li>
+    <li class="ms-Pivot-link ms-Pivot-link--overflow">
+        <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
+    </li>
 </ul>
+<div data-demo="large">
+    <div class="ms-Pivot-content is-selected files">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi erat lacus, auctor eu elit ut, pulvinar eleifend neque. Duis
+        nec nulla id dolor tristique euismod et et nulla. Morbi in ligula risus. Donec urna risus, vehicula at vehicula sed,
+        rhoncus in quam. Nulla nunc magna, egestas vitae tincidunt ac, luctus vitae ipsum. Sed purus magna, aliquam at urna
+        sed, viverra scelerisque ante. Quisque eget pharetra erat. Curabitur aliquet est id lorem tincidunt viverra. Pellentesque
+        semper, risus sed efficitur porttitor, purus quam vehicula tortor, id feugiat nisi odio posuere dui. Nam convallis
+        imperdiet nunc, et porttitor justo fringilla at. Suspendisse viverra molestie diam, id semper purus posuere quis.
+        Curabitur et nisi convallis mi facilisis scelerisque. Vestibulum vulputate tellus nisl, quis malesuada lorem dapibus
+        eu. Ut a mauris dictum, congue ligula a, tempus diam.
+    </div>
+    <div class="ms-Pivot-content recent">
+        Maecenas at nulla in odio varius aliquet. Aliquam viverra pellentesque tincidunt. Etiam ac maximus risus, sed condimentum
+        metus. Quisque convallis felis euismod, dictum nibh vitae, ultricies leo. Curabitur hendrerit et libero sit amet
+        pharetra. Praesent vitae augue quis tellus viverra dapibus. Phasellus luctus turpis neque, vitae dignissim ante rutrum
+        a. Pellentesque quis pretium est, scelerisque ultrices nisl. Maecenas pretium nisi non nulla varius efficitur. Cras
+        sed nisi id ipsum ultricies malesuada ac et nunc.
+    </div>
+    <div class="ms-Pivot-content shared">
+        Donec ut nulla tellus. Donec malesuada felis eget nibh aliquet congue. Curabitur euismod tellus sit amet quam aliquet, ac
+        pulvinar felis euismod. Suspendisse suscipit dolor sit amet urna consectetur, vitae eleifend magna laoreet. Curabitur
+        lacinia massa nec lorem bibendum, ut vestibulum massa hendrerit. Mauris nec finibus tellus, a tempor urna. Nam ac
+        tortor id lacus iaculis sodales eget vitae nunc. Vivamus consectetur gravida ipsum, quis ultricies libero pretium
+        facilisis. Mauris molestie condimentum gravida. Praesent posuere accumsan quam, a feugiat ante porttitor ut. Quisque
+        ligula massa, fermentum dapibus tellus quis, commodo laoreet nibh.
+    </div>
+</div>

--- a/src/components/Pivot/Pivot.Tabs.Large.html
+++ b/src/components/Pivot/Pivot.Tabs.Large.html
@@ -1,10 +1,37 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <ul class="ms-Pivot ms-Pivot--tabs ms-Pivot--large">
-  <li class="ms-Pivot-link is-selected">My files</li>
-  <li class="ms-Pivot-link">Recent</li>
-  <li class="ms-Pivot-link">Shared with me</li>
-  <li class="ms-Pivot-link ms-Pivot-link--overflow">
-    <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
-  </li>
+    <li class="ms-Pivot-link is-selected" data-pivotContent="[data-demo='large-tabs']>.files">My files</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='large-tabs']>.recent">Recent</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='large-tabs']>.shared">Shared with me</li>
+    <li class="ms-Pivot-link ms-Pivot-link--overflow">
+        <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
+    </li>
 </ul>
+<div data-demo="large-tabs">
+    <div class="ms-Pivot-content is-selected files">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi erat lacus, auctor eu elit ut, pulvinar eleifend neque. Duis
+        nec nulla id dolor tristique euismod et et nulla. Morbi in ligula risus. Donec urna risus, vehicula at vehicula sed,
+        rhoncus in quam. Nulla nunc magna, egestas vitae tincidunt ac, luctus vitae ipsum. Sed purus magna, aliquam at urna
+        sed, viverra scelerisque ante. Quisque eget pharetra erat. Curabitur aliquet est id lorem tincidunt viverra. Pellentesque
+        semper, risus sed efficitur porttitor, purus quam vehicula tortor, id feugiat nisi odio posuere dui. Nam convallis
+        imperdiet nunc, et porttitor justo fringilla at. Suspendisse viverra molestie diam, id semper purus posuere quis.
+        Curabitur et nisi convallis mi facilisis scelerisque. Vestibulum vulputate tellus nisl, quis malesuada lorem dapibus
+        eu. Ut a mauris dictum, congue ligula a, tempus diam.
+    </div>
+    <div class="ms-Pivot-content recent">
+        Maecenas at nulla in odio varius aliquet. Aliquam viverra pellentesque tincidunt. Etiam ac maximus risus, sed condimentum
+        metus. Quisque convallis felis euismod, dictum nibh vitae, ultricies leo. Curabitur hendrerit et libero sit amet
+        pharetra. Praesent vitae augue quis tellus viverra dapibus. Phasellus luctus turpis neque, vitae dignissim ante rutrum
+        a. Pellentesque quis pretium est, scelerisque ultrices nisl. Maecenas pretium nisi non nulla varius efficitur. Cras
+        sed nisi id ipsum ultricies malesuada ac et nunc.
+    </div>
+    <div class="ms-Pivot-content shared">
+        Donec ut nulla tellus. Donec malesuada felis eget nibh aliquet congue. Curabitur euismod tellus sit amet quam aliquet, ac
+        pulvinar felis euismod. Suspendisse suscipit dolor sit amet urna consectetur, vitae eleifend magna laoreet. Curabitur
+        lacinia massa nec lorem bibendum, ut vestibulum massa hendrerit. Mauris nec finibus tellus, a tempor urna. Nam ac
+        tortor id lacus iaculis sodales eget vitae nunc. Vivamus consectetur gravida ipsum, quis ultricies libero pretium
+        facilisis. Mauris molestie condimentum gravida. Praesent posuere accumsan quam, a feugiat ante porttitor ut. Quisque
+        ligula massa, fermentum dapibus tellus quis, commodo laoreet nibh.
+    </div>
+</div>

--- a/src/components/Pivot/Pivot.Tabs.html
+++ b/src/components/Pivot/Pivot.Tabs.html
@@ -1,10 +1,37 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <ul class="ms-Pivot ms-Pivot--tabs">
-  <li class="ms-Pivot-link is-selected">My files</li>
-  <li class="ms-Pivot-link">Recent</li>
-  <li class="ms-Pivot-link">Shared with me</li>
-  <li class="ms-Pivot-link ms-Pivot-link--overflow">
-    <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
-  </li>
+    <li class="ms-Pivot-link is-selected" data-pivotContent="[data-demo='tabs']>.files">My files</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='tabs']>.recent">Recent</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='tabs']>.shared">Shared with me</li>
+    <li class="ms-Pivot-link ms-Pivot-link--overflow">
+        <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
+    </li>
 </ul>
+<div data-demo="tabs">
+    <div class="ms-Pivot-content is-selected files">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi erat lacus, auctor eu elit ut, pulvinar eleifend neque. Duis
+        nec nulla id dolor tristique euismod et et nulla. Morbi in ligula risus. Donec urna risus, vehicula at vehicula sed,
+        rhoncus in quam. Nulla nunc magna, egestas vitae tincidunt ac, luctus vitae ipsum. Sed purus magna, aliquam at urna
+        sed, viverra scelerisque ante. Quisque eget pharetra erat. Curabitur aliquet est id lorem tincidunt viverra. Pellentesque
+        semper, risus sed efficitur porttitor, purus quam vehicula tortor, id feugiat nisi odio posuere dui. Nam convallis
+        imperdiet nunc, et porttitor justo fringilla at. Suspendisse viverra molestie diam, id semper purus posuere quis.
+        Curabitur et nisi convallis mi facilisis scelerisque. Vestibulum vulputate tellus nisl, quis malesuada lorem dapibus
+        eu. Ut a mauris dictum, congue ligula a, tempus diam.
+    </div>
+    <div class="ms-Pivot-content recent">
+        Maecenas at nulla in odio varius aliquet. Aliquam viverra pellentesque tincidunt. Etiam ac maximus risus, sed condimentum
+        metus. Quisque convallis felis euismod, dictum nibh vitae, ultricies leo. Curabitur hendrerit et libero sit amet
+        pharetra. Praesent vitae augue quis tellus viverra dapibus. Phasellus luctus turpis neque, vitae dignissim ante rutrum
+        a. Pellentesque quis pretium est, scelerisque ultrices nisl. Maecenas pretium nisi non nulla varius efficitur. Cras
+        sed nisi id ipsum ultricies malesuada ac et nunc.
+    </div>
+    <div class="ms-Pivot-content shared">
+        Donec ut nulla tellus. Donec malesuada felis eget nibh aliquet congue. Curabitur euismod tellus sit amet quam aliquet, ac
+        pulvinar felis euismod. Suspendisse suscipit dolor sit amet urna consectetur, vitae eleifend magna laoreet. Curabitur
+        lacinia massa nec lorem bibendum, ut vestibulum massa hendrerit. Mauris nec finibus tellus, a tempor urna. Nam ac
+        tortor id lacus iaculis sodales eget vitae nunc. Vivamus consectetur gravida ipsum, quis ultricies libero pretium
+        facilisis. Mauris molestie condimentum gravida. Praesent posuere accumsan quam, a feugiat ante porttitor ut. Quisque
+        ligula massa, fermentum dapibus tellus quis, commodo laoreet nibh.
+    </div>
+</div>

--- a/src/components/Pivot/Pivot.html
+++ b/src/components/Pivot/Pivot.html
@@ -1,10 +1,37 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <ul class="ms-Pivot">
-  <li class="ms-Pivot-link is-selected">My files</li>
-  <li class="ms-Pivot-link">Recent</li>
-  <li class="ms-Pivot-link">Shared with me</li>
-  <li class="ms-Pivot-link ms-Pivot-link--overflow">
-    <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
-  </li>
+    <li class="ms-Pivot-link is-selected" data-pivotContent="[data-demo='simple']>.files">My files</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='simple']>.recent">Recent</li>
+    <li class="ms-Pivot-link" data-pivotContent="[data-demo='simple']>.shared">Shared with me</li>
+    <li class="ms-Pivot-link ms-Pivot-link--overflow">
+        <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
+    </li>
 </ul>
+<div data-demo="simple">
+    <div class="ms-Pivot-content is-selected files">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi erat lacus, auctor eu elit ut, pulvinar eleifend neque. Duis
+        nec nulla id dolor tristique euismod et et nulla. Morbi in ligula risus. Donec urna risus, vehicula at vehicula sed,
+        rhoncus in quam. Nulla nunc magna, egestas vitae tincidunt ac, luctus vitae ipsum. Sed purus magna, aliquam at urna
+        sed, viverra scelerisque ante. Quisque eget pharetra erat. Curabitur aliquet est id lorem tincidunt viverra. Pellentesque
+        semper, risus sed efficitur porttitor, purus quam vehicula tortor, id feugiat nisi odio posuere dui. Nam convallis
+        imperdiet nunc, et porttitor justo fringilla at. Suspendisse viverra molestie diam, id semper purus posuere quis.
+        Curabitur et nisi convallis mi facilisis scelerisque. Vestibulum vulputate tellus nisl, quis malesuada lorem dapibus
+        eu. Ut a mauris dictum, congue ligula a, tempus diam.
+    </div>
+    <div class="ms-Pivot-content recent">
+        Maecenas at nulla in odio varius aliquet. Aliquam viverra pellentesque tincidunt. Etiam ac maximus risus, sed condimentum
+        metus. Quisque convallis felis euismod, dictum nibh vitae, ultricies leo. Curabitur hendrerit et libero sit amet
+        pharetra. Praesent vitae augue quis tellus viverra dapibus. Phasellus luctus turpis neque, vitae dignissim ante rutrum
+        a. Pellentesque quis pretium est, scelerisque ultrices nisl. Maecenas pretium nisi non nulla varius efficitur. Cras
+        sed nisi id ipsum ultricies malesuada ac et nunc.
+    </div>
+    <div class="ms-Pivot-content shared">
+        Donec ut nulla tellus. Donec malesuada felis eget nibh aliquet congue. Curabitur euismod tellus sit amet quam aliquet, ac
+        pulvinar felis euismod. Suspendisse suscipit dolor sit amet urna consectetur, vitae eleifend magna laoreet. Curabitur
+        lacinia massa nec lorem bibendum, ut vestibulum massa hendrerit. Mauris nec finibus tellus, a tempor urna. Nam ac
+        tortor id lacus iaculis sodales eget vitae nunc. Vivamus consectetur gravida ipsum, quis ultricies libero pretium
+        facilisis. Mauris molestie condimentum gravida. Praesent posuere accumsan quam, a feugiat ante porttitor ut. Quisque
+        ligula massa, fermentum dapibus tellus quis, commodo laoreet nibh.
+    </div>
+</div>

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -127,6 +127,16 @@
   }
 }
 
+//== Pivot content
+//
+.ms-Pivot-content {
+    display: none;
+}
+
+.ms-Pivot-content.is-selected {
+    display: block;
+}
+
 
 
 @media (min-width: $ms-screen-lg-min) {

--- a/src/components/Pivot/jquery.Pivot.js
+++ b/src/components/Pivot/jquery.Pivot.js
@@ -8,30 +8,50 @@
  * @param  {jQuery Object}  One or more .ms-Pivot components
  * @return {jQuery Object}  The same components (allows for chaining)
  */
-(function ($) {
-  $.fn.Pivot = function () {
+(function($) {
+    $.fn.Pivot = function() {
 
-    /** Go through each pivot we've been given. */
-    return this.each(function () {
+        /** Go through each pivot we've been given. */
+        return this.each(function() {
 
-      var $pivotContainer = $(this);
+            var $pivotContainer = $(this);
 
-      /** When clicking/tapping a link, select it. */
-      $pivotContainer.on('click', '.ms-Pivot-link', function(event) {
-        event.preventDefault();
-        /** Check if current selection has elipses child element **/
-        var $elipsisCheck = $(this).find('.ms-Pivot-ellipsis');
-        
-        /** Only execute when no elipses element can be found **/
-        if($elipsisCheck.length === 0){
-  
-          $(this).siblings('.ms-Pivot-link').removeClass('is-selected');
-          $(this).addClass('is-selected');
-        }
-  
-      });
+            /** When clicking/tapping a link, select it. */
+            $pivotContainer.on('click', '.ms-Pivot-link', function(event) {
+                event.preventDefault();
+                /** Check if current selection has elipses child element **/
+                var $elipsisCheck = $(this).find('.ms-Pivot-ellipsis');
 
-    });
+                /** Find pivot content linked to the current pivot */
+                var pivotContentSelector = $(this).attr('data-pivotContent');
+                var $pivotContent = $(pivotContentSelector);
 
-  };
+                /** Only execute when no elipses element can be found **/
+                if ($elipsisCheck.length === 0) {
+
+                    $(this).siblings('.ms-Pivot-link.is-selected').each(function(index, element) {
+
+                        /** Check if the pivot is attached to any content **/
+                        /** Use data attribute as selector instead of forcing id/class **/
+                        var contentSelector = $(element).attr('data-pivotContent');
+                        if (contentSelector) {
+
+                            /** Remove selection for pivot content **/
+                            $(contentSelector).removeClass('is-selected');
+                        }
+
+                        /** Remove pivot selection  **/
+                        $(this).removeClass('is-selected');
+                    });
+
+                    /* Add pivot & pivot-content selection **/
+                    $(this).addClass('is-selected');
+                    $pivotContent.addClass('is-selected');
+                }
+
+            });
+
+        });
+
+    };
 })(jQuery);


### PR DESCRIPTION
#446 
Implemented support for pivots to be attached to a content element. Currently pivots are able to switch styles between the pivot-links but do not hide/show any content. 

**Commit details**
1. I've updated the pivot JS code to support switching between show/hide for attached pivot-content.
2. I've defined the classes for `ms-Pivot-content`
3. I've updated the pivot samples to include the pivot contents

**Implementation details**
1. Used generic selectors for the data attribute which says what the pivot-link points to so that people aren't forced to use IDs or classes for their content elements
2. Introduced the `ms-Pivot-content` CSS class only as a wrapper on top of the CSS display property. Similar to the Panel css