### PR TITLE
Add new animations for left and right slide ins

### DIFF
--- a/src/sass/Fabric.Animations.Output.scss
+++ b/src/sass/Fabric.Animations.Output.scss
@@ -11,6 +11,32 @@
 
 @import "Fabric.Animations";
 
+// slideRightIn10
+.ms-u-slideRightIn10 {
+    @include ms-u-slideRightIn10;
+}
+@-webkit-keyframes slideRightIn10 {
+    from { -webkit-transform:translate3d(-10px, 0px, 0px); }
+    to { -webkit-transform:translate3d(0px, 0px, 0px); }
+}
+@keyframes slideRightIn10 {
+    from { transform:translate3d(-10px, 0px, 0px); }
+    to { transform:translate3d(0px, 0px, 0px); }
+}
+
+// slideRightIn20
+.ms-u-slideRightIn20 {
+    @include ms-u-slideRightIn20;
+}
+@-webkit-keyframes slideRightIn20 {
+    from { -webkit-transform:translate3d(-20px, 0px, 0px); }
+    to { -webkit-transform:translate3d(0px, 0px, 0px); }
+}
+@keyframes slideRightIn20 {
+    from { transform:translate3d(-20px, 0px, 0px); }
+    to { transform:translate3d(0px, 0px, 0px); }
+}
+
 // slideRightIn40
 .ms-u-slideRightIn40 {
     @include ms-u-slideRightIn40;
@@ -21,6 +47,32 @@
 }
 @keyframes slideRightIn40 {
     from { transform:translate3d(-40px, 0px, 0px); }
+    to { transform:translate3d(0px, 0px, 0px); }
+}
+
+// slideLeftIn10
+.ms-u-slideLeftIn10 {
+    @include ms-u-slideLeftIn10;
+}
+@-webkit-keyframes slideLeftIn10 {
+    from { -webkit-transform:translate3d(10px, 0px, 0px); }
+    to { -webkit-transform:translate3d(0px, 0px, 0px); }
+}
+@keyframes slideLeftIn10 {
+    from { transform:translate3d(10px, 0px, 0px); }
+    to { transform:translate3d(0px, 0px, 0px); }
+}
+
+// slideLeftIn20
+.ms-u-slideLeftIn20 {
+    @include ms-u-slideLeftIn20;
+}
+@-webkit-keyframes slideLeftIn20 {
+    from { -webkit-transform:translate3d(20px, 0px, 0px); }
+    to { -webkit-transform:translate3d(0px, 0px, 0px); }
+}
+@keyframes slideLeftIn20 {
+    from { transform:translate3d(20px, 0px, 0px); }
     to { transform:translate3d(0px, 0px, 0px); }
 }
 

--- a/src/sass/Fabric.Animations.RTL.Output.scss
+++ b/src/sass/Fabric.Animations.RTL.Output.scss
@@ -9,9 +9,29 @@
 @import "Fabric.Animations.Output";
 @import "Fabric.Animations.RTL";
 
+// slideRightIn10
+.ms-u-slideRightIn10 {
+    @include ms-u-slideRightIn10;
+}
+
+// slideRightIn20
+.ms-u-slideRightIn20 {
+    @include ms-u-slideRightIn20;
+}
+
 // slideRightIn40
 .ms-u-slideRightIn40 {
     @include ms-u-slideRightIn40;
+}
+
+// slideLeftIn10
+.ms-u-slideLeftIn10 {
+    @include ms-u-slideLeftIn10;
+}
+
+// slideLeftIn20
+.ms-u-slideLeftIn20 {
+    @include ms-u-slideLeftIn20;
 }
 
 // slideLeftIn40

--- a/src/sass/_Fabric.Animations.RTL.scss
+++ b/src/sass/_Fabric.Animations.RTL.scss
@@ -8,9 +8,29 @@
 
 @import 'Fabric.Animations';
 
+// slideRightIn10
+@mixin ms-u-slideRightIn10 {
+    @include animationMix((fadeIn, slideLeft10), $ms-duration3, $ms-ease1);
+}
+
+// slideRightIn20
+@mixin ms-u-slideRightIn20 {
+    @include animationMix((fadeIn, slideLeft20), $ms-duration3, $ms-ease1);
+}
+
 // slideRightIn40
 @mixin ms-u-slideRightIn40 {
     @include animationMix((fadeIn, slideLeft40), $ms-duration3, $ms-ease1);
+}
+
+// slideLeftIn10
+@mixin ms-u-slideLeftIn10 {
+    @include animationMix((fadeIn, slideRight10), $ms-duration3, $ms-ease1);
+}
+
+// slideLeftIn20
+@mixin ms-u-slideLeftIn20 {
+    @include animationMix((fadeIn, slideRight20), $ms-duration3, $ms-ease1);
 }
 
 // slideLeftIn40

--- a/src/sass/_Fabric.Animations.scss
+++ b/src/sass/_Fabric.Animations.scss
@@ -26,9 +26,29 @@ $ms-duration4: 0.467s;
     @include animationFillMode($ms-fillMode);
 }
 
+// slideRightIn10
+@mixin ms-u-slideRightIn10 {
+    @include animationMix((fadeIn, slideRightIn10), $ms-duration3, $ms-ease1);
+}
+
+// slideRightIn20
+@mixin ms-u-slideRightIn20 {
+    @include animationMix((fadeIn, slideRightIn20), $ms-duration3, $ms-ease1);
+}
+
 // slideRightIn40
 @mixin ms-u-slideRightIn40 {
     @include animationMix((fadeIn, slideRightIn40), $ms-duration3, $ms-ease1);
+}
+
+// slideLeftIn10
+@mixin ms-u-slideLeftIn10 {
+    @include animationMix((fadeIn, slideLeftIn10), $ms-duration3, $ms-ease1);
+}
+
+// slideLeftIn20
+@mixin ms-u-slideLeftIn20 {
+    @include animationMix((fadeIn, slideLeftIn20), $ms-duration3, $ms-ease1);
 }
 
 // slideLeftIn40


### PR DESCRIPTION
Fixes #421

Adds four new animation classes with their associated mixins:
```
.ms-u-slideRightIn10
.ms-u-slideRightIn20
.ms-u-slideLeftIn10
.ms-u-slideLeftIn20
```

Do not merge until the pull request on the documentation site has been merged.