### PR TITLE
Add neutralPrimaryAlt color

### DIFF
--- a/src/sass/Fabric.Color.Mixins.Output.scss
+++ b/src/sass/Fabric.Color.Mixins.Output.scss
@@ -71,6 +71,11 @@
   @include ms-bgColor-neutralPrimary;
 }
 
+.ms-bgColor-neutralPrimaryAlt, 
+.ms-bgColor-neutralPrimaryAlt--hover:hover {
+  @include ms-bgColor-neutralPrimaryAlt;
+}
+
 .ms-bgColor-neutralSecondary, 
 .ms-bgColor-neutralSecondary--hover:hover {
   @include ms-bgColor-neutralSecondary;
@@ -287,6 +292,11 @@
 .ms-borderColor-neutralPrimary, 
 .ms-borderColor-neutralPrimary--hover:hover {
   @include ms-borderColor-neutralPrimary;
+}
+
+.ms-borderColor-neutralPrimaryAlt, 
+.ms-borderColor-neutralPrimaryAlt--hover:hover {
+  @include ms-borderColor-neutralPrimaryAlt;
 }
 
 .ms-borderColor-neutralSecondary, 

--- a/src/sass/Fabric.Typography.Output.scss
+++ b/src/sass/Fabric.Typography.Output.scss
@@ -196,6 +196,11 @@
   @include ms-fontColor-neutralPrimary;
 }
 
+.ms-fontColor-neutralPrimaryAlt, 
+.ms-fontColor-neutralPrimaryAlt--hover:hover {
+  @include ms-fontColor-neutralPrimaryAlt;
+}
+
 .ms-fontColor-neutralSecondary, 
 .ms-fontColor-neutralSecondary--hover:hover {
  @include ms-fontColor-neutralSecondary;

--- a/src/sass/_Fabric.Color.Mixins.scss
+++ b/src/sass/_Fabric.Color.Mixins.scss
@@ -58,6 +58,10 @@
   background-color: $ms-color-neutralPrimary;
 }
 
+@mixin ms-bgColor-neutralPrimaryAlt {
+  background-color: $ms-color-neutralPrimaryAlt;
+}
+
 @mixin ms-bgColor-neutralSecondary {
   background-color: $ms-color-neutralSecondary;
 }
@@ -254,6 +258,10 @@
 
 @mixin ms-borderColor-neutralPrimary {
   border-color: $ms-color-neutralPrimary;
+}
+
+@mixin ms-borderColor-neutralPrimaryAlt {
+  border-color: $ms-color-neutralPrimaryAlt;
 }
 
 @mixin ms-borderColor-neutralSecondary {

--- a/src/sass/_Fabric.Color.Variables.scss
+++ b/src/sass/_Fabric.Color.Variables.scss
@@ -24,6 +24,7 @@ $ms-color-themeLighterAlt: #eff6fc;
 $ms-color-black:               #000000;
 $ms-color-neutralDark:         #212121;
 $ms-color-neutralPrimary:      #333333;
+$ms-color-neutralPrimaryAlt:   #3C3C3C;
 $ms-color-neutralSecondary:    #666666;
 $ms-color-neutralSecondaryAlt: #767676;
 $ms-color-neutralTertiary:     #a6a6a6;

--- a/src/sass/_Fabric.Typography.scss
+++ b/src/sass/_Fabric.Typography.scss
@@ -210,6 +210,10 @@
   color: $ms-color-neutralPrimary;
 }
 
+@mixin ms-fontColor-neutralPrimaryAlt {
+  color: $ms-color-neutralPrimaryAlt;
+}
+
 @mixin ms-fontColor-neutralSecondary {
  color: $ms-color-neutralSecondary;
 }


### PR DESCRIPTION
This PR adds a new color, neutralPrimaryAlt (#3c3c3c), and creates all of the associated mixins and classes.