### PR TITLE
Added a new utility class to set border base width

### DIFF
--- a/src/sass/Fabric.Utilities.Output.scss
+++ b/src/sass/Fabric.Utilities.Output.scss
@@ -12,6 +12,10 @@
   @include ms-u-borderBox;
 }
 
+.ms-u-borderBase {
+  @include ms-u-borderBase;
+}
+
 // Ensures the block expands to the full height to enclose its floated childen.
 .ms-u-clearfix {
   @include ms-u-clearfix;

--- a/src/sass/Fabric.Utilities.Output.scss
+++ b/src/sass/Fabric.Utilities.Output.scss
@@ -12,6 +12,7 @@
   @include ms-u-borderBox;
 }
 
+// To apply border base settings
 .ms-u-borderBase {
   @include ms-u-borderBase;
 }

--- a/src/sass/_Fabric.Utilities.scss
+++ b/src/sass/_Fabric.Utilities.scss
@@ -12,6 +12,7 @@
   box-sizing: border-box;
 }
 
+// For setting the border base width
 @mixin ms-u-borderBase {
   border: 1px solid;
 }

--- a/src/sass/_Fabric.Utilities.scss
+++ b/src/sass/_Fabric.Utilities.scss
@@ -12,6 +12,10 @@
   box-sizing: border-box;
 }
 
+@mixin ms-u-borderBase {
+  border: 1px solid;
+}
+
 // Ensures the block expands to the full height to enclose its floated childen.
 
 @mixin ms-u-clearfix {


### PR DESCRIPTION
Added .ms-u-borderBase to set default base width. One would then apply
both .ms-u-borderBase and .ms-borderColor-[color] to see a colored
border.

https://github.com/OfficeDev/Office-UI-Fabric/issues/332