### PR TITLE
Remove condition preventing is-active CommandBarSearch

### DIFF
--- a/src/components/CommandBar/Jquery.CommandBar.js
+++ b/src/components/CommandBar/Jquery.CommandBar.js
@@ -89,13 +89,10 @@
       processOverflow(overFlowCommands, $OverflowCommand, $OverflowMenu);
 
       // Set Search Behavior
-      if($(window).width() < 640) { 
 
-        $('.ms-CommandBarSearch-iconSearchWrapper').click(function() {
-          $(this).closest('.ms-CommandBarSearch').addClass('is-active');
-        });
-
-      }
+      $('.ms-CommandBarSearch-iconSearchWrapper').click(function() {
+        $(this).closest('.ms-CommandBarSearch').addClass('is-active');
+      });
 
       // Add resize event handler on commandBar
       $(window).resize(function() {


### PR DESCRIPTION
There is if($(window).width() < 640) condition to add is-active class to .ms-CommandBarSearch. 

But `ms-CommandBarSearch` is already closed by `@media screen` at [CommandBar.scss#L230](https://github.com/OfficeDev/Office-UI-Fabric/blob/master/src/components/CommandBar/CommandBar.scss#L230).

For `screens < /*widthLgCollapsed*/ (1023px) > 640px` will never trigger the `.click` event.