### PR TITLE
Fix simple Sass linting issues

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -47,3 +47,10 @@ rules:
       properties:
         - margin
         - content
+
+	# Allow empty lines between blocks and single line rulesets
+	# https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-line-between-blocks.md
+	empty-line-between-blocks:
+    - 1
+    -
+      allow-single-line-rulesets: true

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -55,3 +55,8 @@ rules:
   -
     excluded-identifiers:
       - 'ms'
+      
+  # Enforce hex codes to full length
+  hex-length:
+  - 1
+  - style: long

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -13,12 +13,13 @@ rules:
   mixin-name-format: 0
   force-element-nesting: 0
   force-pseudo-nesting: 0
+  force-attribute-nesting: 0
   nesting-depth: 0
   clean-import-paths:
   - 0
   extends-before-mixins: 2
   extends-before-declarations: 2
-  placeholder-in-extend: 2
+  placeholder-in-extend: 1
   mixins-before-declarations:
     - 0
     -

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -41,16 +41,10 @@ rules:
     - 0
     -
       ignore-custom-properties: true
-  variable-for-property:
-    - 2
-    -
-      properties:
-        - margin
-        - content
 
-	# Allow empty lines between blocks and single line rulesets
-	# https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-line-between-blocks.md
-	empty-line-between-blocks:
-    - 1
-    -
+  # Allow empty lines between blocks and single line rulesets
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-line-between-blocks.md
+  empty-line-between-blocks:
+  - 1
+  -
       allow-single-line-rulesets: true

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -48,3 +48,10 @@ rules:
   - 1
   -
       allow-single-line-rulesets: true
+      
+  # Don't allow vendor prefixes, except for '-ms-*' so that we can target high contrast mode
+  no-vendor-prefixes:
+  - 1
+  -
+    excluded-identifiers:
+      - 'ms'

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -12,6 +12,7 @@ rules:
   variable-name-format: 0
   mixin-name-format: 0
   force-element-nesting: 0
+  force-pseudo-nesting: 0
   nesting-depth: 0
   clean-import-paths:
   - 0
@@ -28,7 +29,7 @@ rules:
   no-warn: 1
   no-debug: 1
   no-ids: 2
-  no-important: 2
+  no-important: 1
   hex-notation:
     - 2
     -

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -51,14 +51,23 @@ rules:
   -
       allow-single-line-rulesets: true
       
-  # Don't allow vendor prefixes, except for '-ms-*' so that we can target high contrast mode
+  # Need to enable these vendor prefixes so that it will allow -ms-high-contrast and -webkit-overflow-scrolling
+  # Would be best to find a way to exclude only those specific properties, not all prefixed properties
   no-vendor-prefixes:
   - 1
   -
     excluded-identifiers:
       - 'ms'
+      - 'webkit'
       
   # Enforce hex codes to full length
   hex-length:
   - 1
   - style: long
+  
+  # Allow properties that are unrecognized by the linter
+  no-misspelled-properties:
+  - 1
+  -
+    extra-properties:
+      - 'overflow-scrolling'

--- a/src/components/AlignmentHost/AlignmentHost.scss
+++ b/src/components/AlignmentHost/AlignmentHost.scss
@@ -1,7 +1,5 @@
-.ms-AlignmentHost {
-  
-}
+// .ms-AlignmentHost {
+// }
 
-.ms-AlignmentHost-inner {
-  
-}
+// .ms-AlignmentHost-inner {  
+// }

--- a/src/components/Breadcrumb/Breadcrumb.scss
+++ b/src/components/Breadcrumb/Breadcrumb.scss
@@ -7,7 +7,7 @@
 
 
 .ms-Breadcrumb {
-  margin: 23px 0 1px 0;
+  margin: 23px 0 1px;
 
   &.is-overflow {
     .ms-Breadcrumb-overflow {
@@ -52,9 +52,9 @@
   .ms-Breadcrumb-overflowButton {
     font-size: $ms-font-size-s;
     display: inline-block;
-    color:$ms-color-themePrimary;
+    color: $ms-color-themePrimary;
     margin-right: -4px;
-    padding: 12px 8px 3px 8px;
+    padding: 12px 8px 3px;
     cursor: pointer;
   }
 }
@@ -82,11 +82,11 @@
     width: 16px;
     height: 16px;
     transform: rotate(45deg);
-    background-color: white;
+    background-color: $ms-color-white;
   }
 
   .ms-ContextualMenu {
-    border: none;
+    border: 0;
     box-shadow: none;
     position: relative;
     width: 190px;
@@ -119,7 +119,7 @@
 }
 
 .ms-Breadcrumb-itemLink {
-  @include ms-font-xl();
+  @include ms-font-xl;
   display: inline-block;
   padding: 0 4px;
   max-width: 160px;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -46,7 +46,7 @@
 		}
 	}
 
-	&:disabled, 
+	&:disabled,
 	&.is-disabled {
 		background-color: $ms-color-neutralLighter;
 		border-color: $ms-color-neutralLighter;
@@ -56,7 +56,7 @@
 			color: $ms-color-neutralTertiary;
 		}
 
-		&:hover, 
+		&:hover,
 		&:focus {
 			outline: 0;
 		}
@@ -74,7 +74,7 @@
 	font-size: $ms-font-size-m;
 }
 
-.ms-Button-icon, 
+.ms-Button-icon,
 .ms-Button-description {
 	display: none;
 }
@@ -104,7 +104,7 @@
 		border-color: $ms-color-themePrimary;
 	}
 
-	&:disabled, 
+	&:disabled,
 	&.is-disabled {
 		background-color: $ms-color-neutralLighter;
 		border-color: $ms-color-neutralLighter;
@@ -120,7 +120,7 @@
 //
 .ms-Button.ms-Button--hero {
   background-color: transparent;
-  border: none;
+  border: 0;
   vertical-align: top;
   line-height: normal;
 
@@ -152,7 +152,7 @@
 		text-decoration: none;
 	}
 
-	&:hover, 
+	&:hover,
 	&:focus {
 		.ms-Button-icon {
 			.ms-Icon {
@@ -177,7 +177,7 @@
 		}
 	}
 
-	&:disabled, 
+	&:disabled,
 	&.is-disabled {
 		.ms-Button-icon {
 			.ms-Icon {
@@ -219,8 +219,8 @@
 	}
 
 	&:hover {
-		.ms-Button-description { 
-			color: $ms-color-neutralDark; 
+		.ms-Button-description {
+			color: $ms-color-neutralDark;
 		}
 	}
 
@@ -228,27 +228,27 @@
 		border-color: $ms-color-themePrimary;
 		background-color: $ms-color-neutralLighter;
 
-		.ms-Button-label { 
-			color: $ms-color-neutralPrimary; 
+		.ms-Button-label {
+			color: $ms-color-neutralPrimary;
 		}
 
-		.ms-Button-description { 
-			color: $ms-color-neutralSecondary; 
+		.ms-Button-description {
+			color: $ms-color-neutralSecondary;
 		}
 	}
 
 	&:active {
 		background-color: $ms-color-themePrimary;
 
-		.ms-Button-description, 
-		.ms-Button-label { 
-			color: $ms-color-white; 
+		.ms-Button-description,
+		.ms-Button-label {
+			color: $ms-color-white;
 		}
 	}
 
-	&:disabled, 
+	&:disabled,
 	&.is-disabled {
-		.ms-Button-label, 
+		.ms-Button-label,
 		.ms-Button-description {
 			color: $ms-color-neutralTertiary;
 		}
@@ -260,7 +260,7 @@
 
 			.ms-Button-label,
 			.ms-Button-description {
-				color: $ms-color-neutralTertiary; 
+				color: $ms-color-neutralTertiary;
 			}
 		}
 	}

--- a/src/components/Callout/Callout.scss
+++ b/src/components/Callout/Callout.scss
@@ -43,34 +43,34 @@ $ms-Callout-commandButtonHeight: 27px;
   margin-top: 20px;
   width: 100%;
   white-space: nowrap;
-  
+
   .ms-Link.ms-Link--hero {
     left: -8px; // Move link inline with body text
   }
-  
+
   .ms-CommandButton.ms-CommandButton--inline {
     height: $ms-Callout-commandButtonHeight;
     line-height: $ms-Callout-commandButtonHeight;
-    
+
     .ms-CommandButton-button {
       height: $ms-Callout-commandButtonHeight;
       line-height: $ms-Callout-commandButtonHeight;
     }
-    
+
     .ms-CommandButton-label {
       line-height: $ms-Callout-commandButtonHeight;
     }
-    
+
     .ms-CommandButton-icon {
       line-height: $ms-Callout-commandButtonHeight;
     }
-    
+
     &:hover .ms-Button,
     &:focus .ms-Button {
       color: $ms-color-themePrimary;
     }
   }
-  
+
   .ms-Callout-button {
     margin-right: 12px;
   }
@@ -117,7 +117,7 @@ $ms-Callout-commandButtonHeight: 27px;
     border-top: 1px solid $ms-color-neutralLight;
     padding-top: 12px;
   }
-  
+
   .ms-Callout-inner {
     padding-bottom: 12px;
   }

--- a/src/components/ChoiceField/ChoiceField.scss
+++ b/src/components/ChoiceField/ChoiceField.scss
@@ -41,7 +41,7 @@
 }
 
 // The original unstyled input element
-.ms-ChoiceField-input { 
+.ms-ChoiceField-input {
 	position: absolute;
 	opacity: 0;
 	top: 8px;
@@ -68,12 +68,11 @@
 		width: 19px;
 		height: 19px;
 		cursor: pointer;
-		position: relative;
 		font-weight: normal;
 		left: -1px;
 		top: -1px;
 		border-radius: 50%;
-		position: absolute;			
+		position: absolute;
 	}
 
 	&:hover {
@@ -116,14 +115,14 @@
 }
 
 // Checkbox
-.ms-ChoiceField-input[type="checkbox"] {
+.ms-ChoiceField-input[type='checkbox'] {
 	+ .ms-ChoiceField-field:after {
 		border-radius: 0;
 	}
 }
 
 // A selected checkbox 
-.ms-ChoiceField-input[type="checkbox"]:checked {
+.ms-ChoiceField-input[type='checkbox']:checked {
 	+ .ms-ChoiceField-field {
 		&:before {
 			@include ms-Icon;

--- a/src/components/CommandBar/CommandBar.scss
+++ b/src/components/CommandBar/CommandBar.scss
@@ -20,17 +20,17 @@ $CommandBarItem-height: $CommandBar-height;
   height: $CommandBar-height;
   white-space: nowrap;
   padding-left: 0;
-  border: 0; 
+  border: 0;
   position: relative;
-  
+
   &:focus {
     outline: none;
   }
-  
+
   .ms-CommandButton--actionButton {
     border-right: 1px solid $ms-color-neutralLight;
   }
-  
+
   //== CommandBar -> ms-Button specific changes
   //
   .ms-Button {
@@ -41,25 +41,25 @@ $CommandBarItem-height: $CommandBar-height;
         padding-right: 0;
       }
     }
-    
+
     &.is-hidden {
       display: none;
     }
   }
-  
+
   .ms-SearchBox,
   .ms-SearchBox-field,
   .ms-SearchBox-label {
     height: 100%;
   }
-  
+
   .ms-SearchBox {
     margin-right: 8px;
     display: inline-block;
     vertical-align: top;
     transition: margin-right $ms-duration2;
   }
-  
+
   .ms-SearchBox.is-collapsed.is-active {
     width: 100%;
     position: absolute;
@@ -67,10 +67,10 @@ $CommandBarItem-height: $CommandBar-height;
     right: 0;
     z-index: $ms-zIndex-front;
   }
-  
+
   // Search is collapsed unless ativated and its only
   // collapsed < L break points
-  
+
   @media only screen and (min-width: $ms-screen-xl-min) {
     .ms-SearchBox {
       margin-right: 24px;

--- a/src/components/CommandButton/CommandButton.scss
+++ b/src/components/CommandButton/CommandButton.scss
@@ -10,31 +10,31 @@ $CommandButton-padding: 8px;
 
 .ms-CommandButton {
   display: inline-block;
-  position: relative;  
-  
+  position: relative;
+
   &.is-hidden {
     display: none;
   }
-  
-  &:disabled, 
+
+  &:disabled,
 	&.is-disabled {
     .ms-CommandButton-button {
       cursor: default;
-      
+
       &:hover {
         background-color: $ms-color-themeLighterAlt;
       }
-      
+
       .ms-CommandButton-label {
         color: $ms-color-neutralTertiary;
       }
-      
+
       .ms-CommandButton-icon {
         color: $ms-color-neutralTertiary;
       }
     }
-	}
-  
+  }
+
   .ms-ContextualHost {
     display: none;
   }
@@ -75,9 +75,10 @@ $CommandButton-padding: 8px;
   position: relative;
   vertical-align: top;
   background: transparent;
-  
+
   &:hover {
     background-color: $ms-color-themeLight;
+
     .ms-CommandButton-label {
 			color: $ms-color-neutralDark;
 		}
@@ -86,7 +87,7 @@ $CommandButton-padding: 8px;
 	&:focus::before {
 		@include  ms-CommandBar-focusRectangle;
 	}
-  
+
   &:focus {
     outline: 0;
   }
@@ -96,7 +97,6 @@ $CommandButton-padding: 8px;
 .ms-CommandButton-splitIcon {
    @include ms-CommandBarButton-buttonBase;
 }
-
 
 .ms-CommandButton-button {
   border: 0;
@@ -115,7 +115,7 @@ $CommandButton-padding: 8px;
   font-size: $ms-font-size-l;
   min-width: 17px;
   height: 100%;
-  
+
   .ms-Icon {
    @include ms-CommandButton-iconBase;
   }
@@ -128,9 +128,9 @@ $CommandButton-padding: 8px;
   height: 100%;
   display: inline-block;
   vertical-align: top;
-  
+
   &:hover {
-    color: $ms-color-neutralDark; 
+    color: $ms-color-neutralDark;
   }
 }
 
@@ -140,11 +140,11 @@ $CommandButton-padding: 8px;
   @include ms-font-l;
   min-width: 17px;
   height: 100%;
-  
+
   .ms-Icon {
-   @include ms-CommandButton-iconBase; 
+   @include ms-CommandButton-iconBase;
   }
-  
+
   &:focus::before {
    @include ms-CommandBar-focusRectangle;
   }
@@ -155,7 +155,7 @@ $CommandButton-padding: 8px;
   margin-left: -4px;
   width: 21px;
   border: 0;
-  
+
   .ms-Icon {
     border-left: 1px solid $ms-color-neutralTertiaryAlt;
     @include ms-CommandButton-iconBase;
@@ -168,7 +168,7 @@ $CommandButton-padding: 8px;
   .ms-CommandButton-icon {
     padding-right: 0;
   }
-  
+
   .ms-CommandButton-label {
     display: none;
   }
@@ -189,7 +189,7 @@ $CommandButton-padding: 8px;
     width: 50px;
     height: $CommandButton-height;
   }
-  
+
   .ms-CommandButton-icon {
     position: absolute;
     top: 50%;
@@ -202,7 +202,7 @@ $CommandButton-padding: 8px;
 }
 
 @mixin ms-CommandButton-pivotLine {
-  content: "";
+  content: '';
   height: 2px;
   position: absolute;
   left: 0;
@@ -215,11 +215,11 @@ $CommandButton-padding: 8px;
 //= Modifier: Pivot Button modifier
 //
 .ms-CommandButton.ms-CommandButton--pivot {
-  
+
   &.is-active:before {
     @include ms-CommandButton-pivotLine;
   }
-  
+
   &:hover {
     &::before {
       @include ms-CommandButton-pivotLine;

--- a/src/components/ContextualHost/ContextualHost.scss
+++ b/src/components/ContextualHost/ContextualHost.scss
@@ -169,7 +169,7 @@
   // Make width larger and remove centering on md+ screens
   .ms-ContextualHost {
     margin: 16px;
-    
+
     &.is-positioned {
       margin: 0;
     }

--- a/src/components/ContextualHost/ContextualHost.scss
+++ b/src/components/ContextualHost/ContextualHost.scss
@@ -1,16 +1,15 @@
-
 .ms-ContextualHost {
   z-index: $ms-zIndex-front;
   margin: 16px auto;
   position: relative;
   min-width: 10px;
   display: none;
-  
+
   &.is-positioned {
     position: absolute;
     margin: 0;
   }
-  
+
   &.is-open {
     display:  inline-block;
   }
@@ -170,6 +169,7 @@
   // Make width larger and remove centering on md+ screens
   .ms-ContextualHost {
     margin: 16px;
+    
     &.is-positioned {
       margin: 0;
     }

--- a/src/components/ContextualMenu/ContextualMenu.scss
+++ b/src/components/ContextualMenu/ContextualMenu.scss
@@ -19,7 +19,7 @@
 .ms-ContextualMenu-item {
   @include ms-u-borderBox;
   position: relative;
-   
+
   &:hover,
   &:active {
     background-color: $ms-color-neutralLight;
@@ -42,23 +42,23 @@
 
   &.is-disabled {
     background-color: $ms-color-white;
-    
-    &:active { 
-      border-color: $ms-color-white; 
+
+    &:active {
+      border-color: $ms-color-white;
     }
-    
+
     .ms-ContextualMenu-link {
       color: $ms-color-neutralTertiary;
       cursor: default;
       pointer-events: none;
     }
 
-    .ms-Icon { 
+    .ms-Icon {
       color: $ms-color-neutralTertiary;
       pointer-events: none;
       cursor: default;
     }
-  } 
+  }
 }
 
 // Modifier: Menu item Dividers
@@ -152,7 +152,7 @@
   .ms-ContextualMenu-link {
     padding-left: 40px;
   }
-  
+
   .ms-Icon {
     position: absolute;
     top: 50%;

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -10,8 +10,8 @@
   @include ms-u-normalize;
   margin-bottom: 17px;
   z-index: $ms-zIndex-DatePicker;
-  
-  .ms-TextField{ position: relative; }
+
+  .ms-TextField { position: relative; }
 }
 
 // Base wrapper for the date picker.
@@ -56,9 +56,9 @@
 }
 
 // When a picker opens, always open it in front of other closed pickers
-.ms-DatePicker-picker--opened { 
-  position: relative; 
-  z-index: $ms-zIndex-front; 
+.ms-DatePicker-picker--opened {
+  position: relative;
+  z-index: $ms-zIndex-front;
 }
 
 
@@ -67,6 +67,7 @@
 .ms-DatePicker-frame {
   padding: 1px;
 }
+
 .ms-DatePicker-wrap {
   margin: -1px;
   padding: 9px;
@@ -101,9 +102,11 @@
     cursor: pointer;
   }
 }
+
 .ms-DatePicker-month {
   margin-left: 15px;
 }
+
 .ms-DatePicker-year {
   margin-left: 5px;
 }
@@ -127,7 +130,8 @@
 
 
 // The days on the calendar.
-.ms-DatePicker-day, .ms-DatePicker-weekday {
+.ms-DatePicker-day,
+.ms-DatePicker-weekday {
   width: 40px;
   height: 40px;
   padding: 0;
@@ -198,11 +202,13 @@
   right: 9px;
   left: 9px;
 }
+
 .ms-DatePicker-yearComponents,
 .ms-DatePicker-decadeComponents {
   position: absolute;
   right: 10px;
 }
+
 .ms-DatePicker-prevMonth,
 .ms-DatePicker-nextMonth,
 .ms-DatePicker-prevYear,
@@ -216,7 +222,6 @@
   margin-left: 10px;
   text-align: center;
   line-height: 40px;
-  text-align: center;
   font-size: 21px;
   color: $ms-color-neutralSecondary;
   position: relative;
@@ -233,9 +238,9 @@
 // button is necessary to toggle the month view.
 .ms-DatePicker-headerToggleView {
   height: 40px;
-  left: 0px;
+  left: 0;
   position: absolute;
-  top: 0px;
+  top: 0;
   width: 140px;
   z-index: $ms-zIndex-middle;
   cursor: pointer;
@@ -355,6 +360,13 @@
   .ms-DatePicker-month,
   .ms-DatePicker-year {
     font-family: $ms-font-family-semilight;
+    font-size: 17px;
+    color: $ms-color-neutralPrimary;
+
+    &:hover {
+      color: $ms-color-neutralPrimary;
+      cursor: default;
+    }
   }
 
   .ms-DatePicker-header {
@@ -367,18 +379,13 @@
     @include ms-u-borderBox;
     border-right: 1px solid $ms-color-neutralLight;
     width: 220px;
+    margin: -10px 0;
+    padding: 10px 0;
   }
 
   // Show the month picker.
   .ms-DatePicker-monthPicker {
     display: block;
-  }
-
-
-  // Swap margin for padding so that the border extends the full height.
-  .ms-DatePicker-dayPicker {
-    margin: -10px 0;
-    padding: 10px 0;
   }
 
   // Style the the month and year pickers.
@@ -389,11 +396,10 @@
     position: absolute;
   }
 
-
   .ms-DatePicker-optionGrid {
     width: 200px;
     height: auto;
-    margin: 10px 0 0 0;
+    margin: 10px 0 0;
   }
 
   // Size the month components to the day picker's new width
@@ -404,16 +410,6 @@
   // Size and position of the month and year labels.
   .ms-DatePicker-month {
     margin-left: 12px;
-  }
-  .ms-DatePicker-month,
-  .ms-DatePicker-year {
-    font-size: 17px;
-    color: $ms-color-neutralPrimary;
-
-    &:hover {
-      color: $ms-color-neutralPrimary;
-      cursor: default;
-    }
   }
 
 

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -22,7 +22,6 @@
   display: none;
   position: absolute;
   margin:  0;
-  padding: 0;
   border: 0;
   background: none;
   cursor: pointer;
@@ -55,13 +54,13 @@
   width: 100%;
 
   // Add margin bottom between compound buttons
-  .ms-Button.ms-Button--compound:not(:last-child) { 
-    margin-bottom: 20px; 
+  .ms-Button.ms-Button--compound:not(:last-child) {
+    margin-bottom: 20px;
   }
 }
 
 .ms-Dialog-subText {
-  margin: 0 0 20px 0;
+  margin: 0 0 20px;
   padding-top: 8px;
   font-family: $ms-font-family-semilight;
   color: $ms-color-neutralPrimary;
@@ -75,24 +74,24 @@
   line-height: 24px;
   margin: 20px 0 0;
   font-size: 0;
-  
-  .ms-Button { 
-    line-height: normal; 
+
+  .ms-Button {
+    line-height: normal;
   }
 }
 
 .ms-Dialog-actionsRight {
   text-align: right;
   font-size: 0;
-  
+
   // Reset spacing for first button
   .ms-Dialog-action:first-child {
-    margin: 0; 
+    margin: 0;
   }
-  
+
   // Spacing between bottom buttons
-  .ms-Dialog-action + .ms-Dialog-action { 
-    margin: 0 0 0 16px; 
+  .ms-Dialog-action + .ms-Dialog-action {
+    margin: 0 0 0 16px;
   }
 }
 
@@ -151,6 +150,6 @@
   .ms-Dialog-main {
     width: auto;
     min-width: 288px;
-    max-width: 340px; 
+    max-width: 340px;
   }
 }

--- a/src/components/DialogHost/DialogHost.scss
+++ b/src/components/DialogHost/DialogHost.scss
@@ -1,5 +1,5 @@
 .ms-DialogHost {
-  @include drop-shadow();
+  @include drop-shadow;
   background-color: $ms-color-white;
   box-sizing: border-box;
   line-height: 1.35;

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -25,7 +25,7 @@
   &:hover,
   &:active {
     .ms-Dropdown-title {
-      border-color: $ms-color-neutralSecondaryAlt; 
+      border-color: $ms-color-neutralSecondaryAlt;
     }
   }
 
@@ -44,7 +44,7 @@
     color: $ms-color-neutralTertiary;
     cursor: default;
   }
-  
+
   .ms-Dropdown-caretDown {
     color: $ms-color-neutralTertiary;
   }
@@ -129,7 +129,7 @@
   white-space: nowrap;
 
   // Shorten the first and last items to maintain baseline alignment.
-  &:first-child, 
+  &:first-child,
   &:last-child {
     height: 39px;
   }

--- a/src/components/Facepile/Facepile.scss
+++ b/src/components/Facepile/Facepile.scss
@@ -17,7 +17,7 @@
 }
 
 .ms-Facepile-addButton {
-  @include button-reset();
+  @include button-reset;
   position: relative;
   height: 32px;
   width: 32px;

--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -6,7 +6,7 @@
 // Form field label styles
 
 @mixin ms-Label-is-disabled {
-     color: $ms-color-neutralPrimary; 
+     color: $ms-color-neutralPrimary;
 }
 
 @mixin ms-Label-is-required {

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -12,7 +12,7 @@
   text-decoration: none;
   cursor: pointer;
   outline: none;
-  
+
   &:hover,
   &:focus {
     color: $ms-color-themeDarker;

--- a/src/components/List/List.scss
+++ b/src/components/List/List.scss
@@ -20,12 +20,12 @@
 		.ms-ListItem {
 			@include ms-u-sm4;
 			float: left;
-			border-width: 0 1px 1px 0;
+			border-width: 0 1px 1px;
 		}
 
 		// Remove the border from the last column.
 		.ms-ListItem:nth-child(3n) {
-			border-width: 0 0 1px 0;
+			border-width: 0 0 1px;
 		}
 	}
 }

--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -15,8 +15,8 @@
   display: block;
 }
 
-.ms-ListItem-primaryText, 
-.ms-ListItem-secondaryText, 
+.ms-ListItem-primaryText,
+.ms-ListItem-secondaryText,
 .ms-ListItem-tertiaryText {
   @include noWrap;
   display: block;
@@ -109,7 +109,8 @@
   border-left: 3px solid $ms-color-themePrimary;
   padding-left: 27px; // Reduce padding to allow room for border.
 
-  .ms-ListItem-secondaryText, .ms-ListItem-metaText {
+  .ms-ListItem-secondaryText,
+  .ms-ListItem-metaText {
     color: $ms-color-themePrimary;
     font-family: $ms-font-family-semibold;
   }
@@ -172,7 +173,7 @@
     border: 1px solid transparent;
   }
 
-  &:before, 
+  &:before,
   &:hover:before {
     @include ms-Icon;
     content: '\e041';

--- a/src/components/MessageBanner/MessageBanner.scss
+++ b/src/components/MessageBanner/MessageBanner.scss
@@ -9,7 +9,7 @@ $MessageBanner-height: 52px;
 $MessageBanner-iconSize: 40px;
 
 .ms-MessageBanner {
-  @include ms-font-s();
+  @include ms-font-s;
   position: relative;
   border-bottom: 1px solid $ms-color-neutralSecondaryAlt;
   background-color: $ms-color-themeLighterAlt;
@@ -18,16 +18,14 @@ $MessageBanner-iconSize: 40px;
   height: $MessageBanner-height;
   text-align: center;
   overflow: hidden;
-  @include ms-u-slideDownIn20();
+  @include ms-u-slideDownIn20;
 
   .ms-Icon {
     font-size: 16px;
   }
-}
 
-.ms-MessageBanner {
   &.hide {
-    @include ms-u-slideUpOut20();
+    @include ms-u-slideUpOut20;
   }
 
   &.is-hidden {
@@ -40,7 +38,7 @@ $MessageBanner-iconSize: 40px;
   height: $MessageBanner-height;
   width: $MessageBanner-iconSize;
   cursor: pointer;
-  border: none;
+  border: 0;
   background-color: transparent;
 
   &:focus {
@@ -104,10 +102,6 @@ $MessageBanner-iconSize: 40px;
 
 
 @media screen and (max-width: 479px) {
-  .ms-MessageBanner-expand {
-    display: inline-block;
-  }
-
   .ms-MessageBanner-action {
     margin: 0;
     display: block;
@@ -117,11 +111,12 @@ $MessageBanner-iconSize: 40px;
 
   .ms-MessageBanner-text {
     margin-left: -25px;
-    padding: 18px 0 10px 0;
+    padding: 18px 0 10px;
     min-width: 240px;
   }
 
   .ms-MessageBanner-expand {
+    display: inline-block;
     padding: 0;
     margin-left: -5px;
     width: 20px;

--- a/src/components/OrgChart/OrgChart.scss
+++ b/src/components/OrgChart/OrgChart.scss
@@ -18,7 +18,7 @@
 
 .ms-OrgChart-list {
   padding: 0;
-  margin: 12px 0 16px 0;
+  margin: 12px 0 16px;
 }
 
 .ms-OrgChart-listItem {
@@ -30,7 +30,7 @@
 }
 
 .ms-OrgChart-listItemBtn {
-  @include button-reset();
+  @include button-reset;
   position: relative;
   height: 50px;
   width: 100%;

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -17,9 +17,9 @@ $Panel-margin-md: 48px;
 $Panel-margin-lg: 428px;
 $Panel-margin-xl: 176px;
 $CommandBarHeight: 40px;
-$CommandButtonLightBlue: #b5d8f4;
-$CommandButtonLighterBlue: #d7eaf9;
-$CommandButtonDarkBlue: #07288b;
+$CommandButtonLightBlue: #B5D8F4;
+$CommandButtonLighterBlue: #D7EAF9;
+$CommandButtonDarkBlue: #07288B;
 $CommandButtonBlue: #2488D8;
 
 // The panel itself, where the content goes.
@@ -28,20 +28,18 @@ $CommandButtonBlue: #2488D8;
   width: 100%;
   max-width: $Panel-width-sm;
   display: block;
-  position: relative;
-  @include drop-shadow(-30px, 0px, 30px, -30px, .2);
+  @include drop-shadow(-30px, 0, 30px, -30px, .2);
   position: absolute;
   top: 0;
   bottom: 0;
   right: 0;
-  background-color: $ms-color-white;
   z-index: $ms-zIndex-front;
-  
+
   // Animations -- Default (anchored right)
   &.animate-in {
     @include ms-u-slideLeftIn40;
   }
-  
+
   &.animate-out {
     @include ms-u-slideRightOut40;
   }
@@ -78,7 +76,7 @@ $CommandButtonBlue: #2488D8;
   left: 0;
   border-left: 1px solid $ms-color-neutralLight;
   border-right: 1px solid $ms-color-neutralLight;
-  @include drop-shadow(-30px, 0px, 30px, 30px, .2);
+  @include drop-shadow(-30px, 0, 30px, 30px, .2);
 
   // Commands and content inner are not displayed
   // Note: Replace with a leftnav menu.
@@ -102,6 +100,7 @@ $CommandButtonBlue: #2488D8;
     .ms-Panel-main {
       @include ms-u-slideLeftOut40;
     }
+
     .ms-Overlay {
       @include ms-u-fadeOut200;
     }
@@ -110,7 +109,7 @@ $CommandButtonBlue: #2488D8;
 
 // The close button in the top right (x)
 .ms-Panel-closeButton {
-  @include button-reset();
+  @include button-reset;
   position: absolute;
   right: 8px;
   top: 0;
@@ -155,7 +154,7 @@ $CommandButtonBlue: #2488D8;
 
   @media (min-width: $ms-screen-xl-min) {
     margin-top: 30px;
-  } 
+  }
 }
 
 //== Modifier: Deprecated Animated commandbar
@@ -164,7 +163,7 @@ $CommandButtonBlue: #2488D8;
   .ms-CommandBar {
     @media (min-width: $ms-screen-md-min) {
       display: block;
-    }    
+    }
   }
 
   .ms-CommandBarItem {
@@ -221,7 +220,7 @@ $CommandButtonBlue: #2488D8;
 
   &.is-open {
     .ms-CommandBar {
-      @include ms-u-slideDownIn20();
+      @include ms-u-slideDownIn20;
       animation-delay: 250ms;
     }
 

--- a/src/components/PanelHost/PanelHost.scss
+++ b/src/components/PanelHost/PanelHost.scss
@@ -7,7 +7,6 @@ $Panel-width-lightDismiss: 272px;
   position: absolute;
   right: 0;
   top: 0;
-  z-index: $ms-zIndex-Panel;
   pointer-events: none;
   z-index: $ms-zIndex-front;
 }
@@ -29,7 +28,6 @@ $Panel-width-lightDismiss: 272px;
   display: block;
   opacity: 1;
   pointer-events: auto;
-  display: block;
 
   .ms-Overlay {
     display: block;
@@ -62,7 +60,7 @@ $Panel-width-lightDismiss: 272px;
         @include ms-u-fadeIn200;
       }
     }
-    
+
     &.ms-Panel-animateOut {
       @include ms-u-slideRightOut40;
 
@@ -82,7 +80,7 @@ $Panel-width-lightDismiss: 272px;
 
     &.ms-Panel--left.ms-Panel-animateOut {
       @include ms-u-slideLeftOut40;
-      
+
       .ms-Overlay {
         @include ms-u-fadeOut200;
       }

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -18,11 +18,11 @@ $ms-Persona-leftPadding: 16px;
 // Box that contains the search field and selected people.
 .ms-PeoplePicker-searchBox {
   border-bottom: 2px solid $ms-color-themePrimary;
-  
+
   .ms-TextField {
-    border: none;
+    border: 0;
     margin-bottom: 0;
-    
+
     .ms-TextField-field {
       min-height: 40px;
       border: 0;
@@ -46,11 +46,10 @@ $ms-Persona-leftPadding: 16px;
 
 // Button to remove a selected person.
 .ms-PeoplePicker-personaRemove {
-  @include button-reset();
+  @include button-reset;
   background-color: $ms-color-neutralLighter;
   color: $ms-color-neutralSecondary;
   display: inline-block;
-  float: left;
   text-align: center;
   height: 32px;
   width: 32px;
@@ -122,23 +121,22 @@ $ms-Persona-leftPadding: 16px;
   margin-bottom: 8px;
   padding-left: $ms-Persona-leftPadding;
   cursor: pointer;
-  
+
   &:hover {
     background-color: $ms-color-neutralLight;
   }
-  
+
   .ms-PeoplePicker-resultAction {
       &:hover {
         background-color: $ms-color-neutralTertiaryAlt;
         outline: 1px solid transparent;
       }
   }
-  
+
   &.is-selected {
     background-color: $ms-color-themeLight;
-    
+
     .ms-PeoplePicker-resultAction {
-      
       &:hover {
         background-color: $ms-color-themeTertiary;
       }
@@ -149,7 +147,7 @@ $ms-Persona-leftPadding: 16px;
 // Result buttons
 .ms-PeoplePicker-resultBtn,
 .ms-PeoplePicker-peopleListBtn {
-  @include button-reset();
+  @include button-reset;
   position: relative;
   box-sizing: border-box;
   height: 34px;
@@ -157,7 +155,7 @@ $ms-Persona-leftPadding: 16px;
   background: none;
   border: 0;
   text-align: left;
-  margin: 0 0 10px 0;
+  margin: 0 0 10px;
   padding: 0 0 0 9px;
 
   @media (min-width: $ms-screen-md-min) {
@@ -189,10 +187,10 @@ $ms-Persona-leftPadding: 16px;
 
 // Actionable icon on a result
 .ms-PeoplePicker-resultAction {
-  @include button-reset();
+  @include button-reset;
   display: block;
   height: 100%;
-  transition: background-color 0.367s $ms-ease1;
+  transition: background-color .367s $ms-ease1;
   position: absolute;
   right: 0;
   top: 0;
@@ -275,7 +273,7 @@ $ms-Persona-leftPadding: 16px;
 }
 
 .ms-PeoplePicker-searchMoreBtn {
-  @include button-reset();
+  @include button-reset;
   position: relative;
   height: 69px;
   width: 100%;
@@ -514,10 +512,20 @@ $ms-Persona-leftPadding: 16px;
       height: $personaItemHeight;
     }
   }
-  
+
   .ms-PeoplePicker-resultAction {
     @media (min-width: $ms-screen-md-min) {
       height: $personaItemHeight;
+    }
+  }
+
+  .ms-PersonaCard {
+    display: none;
+    position: absolute;
+    height: 200px;
+
+    &.is-active {
+      display: block;
     }
   }
 
@@ -562,18 +570,6 @@ $ms-Persona-leftPadding: 16px;
     left: 14px;
     height: 20px;
     width: 20px;
-  }
-}
-
-.ms-PeoplePicker.ms-PeoplePicker--Facepile {
-  .ms-PersonaCard {
-    display: none;
-    position: absolute;
-    height: 200px;
-
-    &.is-active {
-      display: block;
-    }
   }
 }
 

--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -7,21 +7,21 @@
 
 
 //= Colors used in the initials color block
-$ms-color-initials-lightBlue:   #6ba5e7;
-$ms-color-initials-blue:        #2d89ef;
-$ms-color-initials-darkBlue:    #2b5797;
-$ms-color-initials-teal:        #00aba9;
-$ms-color-initials-lightGreen:  #99b433;
-$ms-color-initials-green:       #00a300;
-$ms-color-initials-darkGreen:   #1e7145;
-$ms-color-initials-lightPink:   #e773bd;
-$ms-color-initials-pink:        #ff0097;
-$ms-color-initials-magenta:     #7e3878;
-$ms-color-initials-purple:      #603cba;
-$ms-color-initials-black:       #1d1d1d;
-$ms-color-initials-orange:      #da532c;
-$ms-color-initials-red:         #ee1111;
-$ms-color-initials-darkRed:     #b91d47;
+$ms-color-initials-lightBlue:   #6BA5E7;
+$ms-color-initials-blue:        #2D89EF;
+$ms-color-initials-darkBlue:    #2B5797;
+$ms-color-initials-teal:        #00ABA9;
+$ms-color-initials-lightGreen:  #99B433;
+$ms-color-initials-green:       #00A300;
+$ms-color-initials-darkGreen:   #1E7145;
+$ms-color-initials-lightPink:   #E773BD;
+$ms-color-initials-pink:        #FF0097;
+$ms-color-initials-magenta:     #7E3878;
+$ms-color-initials-purple:      #603CBA;
+$ms-color-initials-black:       #1D1D1D;
+$ms-color-initials-orange:      #DA532C;
+$ms-color-initials-red:         #EE1111;
+$ms-color-initials-darkRed:     #B91D47;
 
 // Persona Sizes
 $ms-Persona-sizeTiny: 30px;
@@ -52,7 +52,7 @@ $ms-Persona-presenceSizeXl: 28px;
   display: table;
   table-layout: fixed;
   border-collapse: separate;
-  
+
   .ms-ContextualHost {
     display: none;
   }
@@ -101,45 +101,59 @@ $ms-Persona-presenceSizeXl: 28px;
   &.ms-Persona-initials--lightBlue {
     background-color: $ms-color-initials-lightBlue;
   }
+
   &.ms-Persona-initials--blue {
     background-color: $ms-color-initials-blue;
   }
+
   &.ms-Persona-initials--darkBlue {
     background-color: $ms-color-initials-darkBlue;
   }
+
   &.ms-Persona-initials--teal {
     background-color: $ms-color-initials-teal;
   }
+
   &.ms-Persona-initials--lightGreen {
     background-color: $ms-color-initials-lightGreen;
   }
+
   &.ms-Persona-initials--green {
     background-color: $ms-color-initials-green;
   }
+
   &.ms-Persona-initials--darkGreen {
     background-color: $ms-color-initials-darkGreen;
   }
+
   &.ms-Persona-initials--lightPink {
     background-color: $ms-color-initials-lightPink;
   }
+
   &.ms-Persona-initials--pink {
     background-color: $ms-color-initials-pink;
   }
+
   &.ms-Persona-initials--magenta {
     background-color: $ms-color-initials-magenta;
   }
+
   &.ms-Persona-initials--purple {
     background-color: $ms-color-initials-purple;
   }
+
   &.ms-Persona-initials--black {
     background-color: $ms-color-initials-black;
   }
+
   &.ms-Persona-initials--orange {
     background-color: $ms-color-initials-orange;
   }
+
   &.ms-Persona-initials--red {
     background-color: $ms-color-initials-red;
   }
+
   &.ms-Persona-initials--darkRed {
     background-color: $ms-color-initials-darkRed;
   }
@@ -149,14 +163,13 @@ $ms-Persona-presenceSizeXl: 28px;
   position: absolute;
   top: 0;
   left: 0;
-  width: $ms-Persona-sizeMd;
   height: $ms-Persona-sizeMd;
   z-index: $ms-zIndex-front;
   width: 100%;
-}
 
-.ms-Persona-image[src=""] {
-   display: none;
+  &[src=''] {
+    display: none;
+  }
 }
 
 .ms-Persona-presence {
@@ -193,7 +206,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona-secondaryText,
 .ms-Persona-tertiaryText,
 .ms-Persona-optionalText {
-  @include noWrap();
+  @include noWrap;
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -307,8 +320,10 @@ $ms-Persona-presenceSizeXl: 28px;
   padding: 0;
   background-color: transparent;
 
-  .ms-Persona-primaryText:after {
-    content: ';';
+  .ms-Persona-primaryText {
+    &::after {
+      content: ';';
+    }
   }
 }
 
@@ -330,7 +345,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona.ms-Persona--facePile,
 .ms-Persona.ms-Persona--token {
   height: $ms-Persona-sizeXs;
-  
+
   .ms-Persona-imageArea,
   .ms-Persona-image {
     max-width: $ms-Persona-sizeXs;
@@ -381,7 +396,7 @@ $ms-Persona-presenceSizeXl: 28px;
 //
 .ms-Persona.ms-Persona--sm {
   height: $ms-Persona-sizeSm;
-  
+
   .ms-Persona-imageArea,
   .ms-Persona-image {
     max-width: $ms-Persona-sizeSm;
@@ -432,7 +447,7 @@ $ms-Persona-presenceSizeXl: 28px;
 //
 .ms-Persona.ms-Persona--lg {
   height: $ms-Persona-sizeLg;
-  
+
   .ms-Persona-imageArea,
   .ms-Persona-image {
     max-width: $ms-Persona-sizeLg;
@@ -460,7 +475,7 @@ $ms-Persona-presenceSizeXl: 28px;
     line-height: $ms-Persona-presenceSizeLg;
     font-size: $ms-font-size-m;
   }
-  
+
   .ms-Persona-details {
     padding-left: $ms-Persona-sizeLg + $ms-Persona-imageDetailsLgSpace;
   }
@@ -471,9 +486,6 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .ms-Persona-tertiaryText {
     padding-top: 5px;
-  }
-
-  .ms-Persona-tertiaryText {
     display: block; // Show tertiary text
   }
 }
@@ -494,7 +506,7 @@ $ms-Persona-presenceSizeXl: 28px;
 //
 .ms-Persona.ms-Persona--xl {
   height: $ms-Persona-sizeXl;
-  
+
   .ms-Persona-imageArea,
   .ms-Persona-image {
     max-width: $ms-Persona-sizeXl;
@@ -621,9 +633,9 @@ $ms-Persona-presenceSizeXl: 28px;
       width: 100%;
       height: 100%;
       position: absolute;
-      top: 0px;
-      left: 0px;
-      box-shadow: 0px 0 0 2px $ms-color-presence-busy-average inset;
+      top: 0;
+      left: 0;
+      box-shadow: 0 0 0 2px $ms-color-presence-busy-average inset;
       border-radius: 50%;
     }
 
@@ -652,7 +664,7 @@ $ms-Persona-presenceSizeXl: 28px;
       &:after {
         top: 13px;
       }
-    } 
+    }
   }
 }
 
@@ -662,7 +674,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-presence {
     background-color: $ms-color-presence-blocked-background;
     // Use a gradient to include the stripe on modern browsers.
-    background-image: linear-gradient( to bottom, $ms-color-presence-blocked-background 0%, $ms-color-presence-blocked-background 48%, $ms-color-presence-blocked-line 40%, $ms-color-presence-blocked-line 58%, $ms-color-presence-blocked-background 52%, $ms-color-presence-blocked-background 100% );
+    background-image: linear-gradient(to bottom, $ms-color-presence-blocked-background 0%, $ms-color-presence-blocked-background 48%, $ms-color-presence-blocked-line 40%, $ms-color-presence-blocked-line 58%, $ms-color-presence-blocked-background 52%, $ms-color-presence-blocked-background 100%);
 
     &:before,
     &:after {
@@ -685,7 +697,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona.ms-Persona--busy.ms-Persona--square {
   .ms-Persona-presence {
     // Replace solid background with stripes on modern browsers.
-    background: repeating-linear-gradient( -45deg, $ms-color-presence-busy-stripe-light, $ms-color-presence-busy-stripe-light 3px, $ms-color-presence-busy-stripe-dark 3px, $ms-color-presence-busy-stripe-dark 6px );
+    background: repeating-linear-gradient(-45deg, $ms-color-presence-busy-stripe-light, $ms-color-presence-busy-stripe-light 3px, $ms-color-presence-busy-stripe-dark 3px, $ms-color-presence-busy-stripe-dark 6px);
   }
 }
 
@@ -703,7 +715,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona.ms-Persona--dnd.ms-Persona--square {
   .ms-Persona-presence {
     // Use a gradient to include the stripe on modern browsers.
-    background-image: linear-gradient( to bottom, $ms-color-presence-dnd-background 0%, $ms-color-presence-dnd-background 48%, $ms-color-presence-dnd-line 48%, $ms-color-presence-dnd-line 52%, $ms-color-presence-dnd-background 52%, $ms-color-presence-dnd-background 100% );
+    background-image: linear-gradient(to bottom, $ms-color-presence-dnd-background 0%, $ms-color-presence-dnd-background 48%, $ms-color-presence-dnd-line 48%, $ms-color-presence-dnd-line 52%, $ms-color-presence-dnd-background 52%, $ms-color-presence-dnd-background 100%);
   }
 }
 
@@ -721,25 +733,25 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona.ms-Persona--facePile {
   display: inline-block;
   width: auto;
-  
+
   &:hover {
     cursor: pointer;
   }
-  
+
   .ms-Persona-imageArea {
     position: relative;
     width: 100%;
     min-width: $ms-Persona-sizeXs;
   }
-  
+
   .ms-Persona-initials {
     position: relative;
   }
-  
+
   .ms-Persona-details {
     display: none;
   }
-  
+
   .ms-Persona-presence {
     display: none;
   }
@@ -753,11 +765,11 @@ $ms-Persona-presenceSizeXl: 28px;
   background-color: $ms-color-neutralLighter;
   border-radius: 20px;
   margin-bottom: 4px;
-  
+
   &:hover {
     cursor: pointer;
   }
-  
+
   .ms-Persona-actionIcon {
     border-radius: 20px;
     display: inline-block;
@@ -767,29 +779,29 @@ $ms-Persona-presenceSizeXl: 28px;
     line-height: 30px;
     transition: background-color $ms-duration1 $ms-ease1;
     text-align: center;
-    
+
     &:hover {
       background-color: $ms-color-neutralLight;
     }
   }
-  
+
   .ms-Persona-imageArea {
     width: 100%;
     min-width: $ms-Persona-sizeXs;
   }
-  
+
   .ms-Persona-details {
     height: 30px;
     display: inline-block;
     width: auto;
     padding-right: 8px;
   }
-  
+
   .ms-Persona-primaryText {
     padding-top: 0;
     line-height: 30px;
   }
-  
+
   .ms-Persona-initials {
     position: relative;
   }

--- a/src/components/PersonaCard/PersonaCard.scss
+++ b/src/components/PersonaCard/PersonaCard.scss
@@ -54,9 +54,9 @@
   &:active {
     color: $ms-color-themePrimary;
   }
-  
+
   &:before {
-    content: "";
+    content: '';
     position: absolute;
     width: 100%;
     height: 100%;
@@ -74,7 +74,7 @@
     &:after {
       @include ms-u-borderBox;
       @include rotate(45deg);
-      content: "";
+      content: '';
       width: 10px;
       height: 10px;
       border: 1px solid $ms-color-neutralTertiaryAlt;
@@ -123,11 +123,11 @@
   color: $ms-color-neutralSecondary;
   padding: 9px 20px;
   box-sizing: border-box;
-  
+
   &.is-active {
     display: block;
   }
-  
+
   // State: Contents are collapsed to a single line.
   &.is-collapsed {
     height: 30px;
@@ -140,7 +140,7 @@
   }
 }
 
-.ms-PersonaCard-details[data-detail-id="org"] {
+.ms-PersonaCard-details[data-detail-id='org'] {
   max-height: 300px;
 }
 

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -23,7 +23,7 @@
   line-height: 27px;
   margin-right: 15px;
 
-  &:hover, 
+  &:hover,
   &:focus {
     color: $ms-color-black;
     cursor: pointer;
@@ -48,9 +48,9 @@
     color: $ms-color-themePrimary;
   }
 
-  &:hover:not(.is-selected), 
-  &:focus:not(.is-selected) { 
-    color: $ms-color-neutralDark; 
+  &:hover:not(.is-selected),
+  &:focus:not(.is-selected) {
+    color: $ms-color-neutralDark;
   }
 
   &:active {
@@ -98,8 +98,8 @@
     padding: 0 10px;
 
     &:hover:not(.is-selected):not(.ms-Pivot-link--overflow),
-    &:focus:not(.is-selected):not(.ms-Pivot-link--overflow) { 
-      color: $ms-color-black; 
+    &:focus:not(.is-selected):not(.ms-Pivot-link--overflow) {
+      color: $ms-color-black;
     }
 
     &:active {
@@ -116,7 +116,7 @@
   }
 
   .ms-Pivot-link.ms-Pivot-link--overflow {
-    &:hover:not(.is-selected), 
+    &:hover:not(.is-selected),
     &:focus:not(.is-selected) {
       background-color: $ms-color-white;
     }

--- a/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -11,7 +11,7 @@ $ProgressIndicatorButtonsWidth: 218px;
 $ProgressIndicatorTextHeight: 18px;
 
 .ms-ProgressIndicator-itemName {
-  @include ms-font-m();
+  @include ms-font-m;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -20,7 +20,7 @@ $ProgressIndicatorTextHeight: 18px;
 }
 
 .ms-ProgressIndicator-itemDescription {
-  @include ms-font-m();
+  @include ms-font-m;
   color: $ms-color-neutralSecondaryAlt;
   font-size: 11px;
   line-height: $ProgressIndicatorTextHeight;

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -14,32 +14,34 @@
   overflow: hidden;
   transition: width $ms-duration1;
   width: 180px;
-  
+
   .ms-CommandButton {
     display: none;
   }
-  
+
   // State: Active searchbox
   &.is-active {
     z-index: $ms-zIndex-front;
+
     .ms-SearchBox-label {
       display: none;
     }
+
     .ms-CommandButton {
       display: block;
     }
   }
-  
+
   &.has-text {
     .ms-SearchBox-text {
       display: none;
     }
   }
-  
+
   &:hover {
     background-color: $ms-color-themeLighter;
     border-color: $ms-color-themePrimary;
-    
+
     .ms-SearchBox-label {
       color: $ms-color-black;
 
@@ -48,15 +50,17 @@
       }
     }
   }
-  
+
   // State: Disabled searchbox
   &.is-disabled {
     .ms-SearchBox-label {
       @include ms-Label-is-disabled;
     }
+
     .ms-SearchBox-icon {
       color: $ms-color-neutralTertiaryAlt;
     }
+
     .ms-SearchBox-field {
       background-color: $ms-color-neutralLighter;
       border-color: $ms-color-neutralLighter;
@@ -87,7 +91,7 @@
     border-color: $ms-color-themePrimary;
     background-color: $ms-color-themeLighter;
   }
-  
+
   &::-ms-clear {
     display: none;
   }
@@ -100,12 +104,13 @@
   height: 100%;
   display: none;
   z-index: $ms-zIndex-front + 1;
-  
+
   .ms-CommandButton-button {
     background-color: $ms-color-themePrimary;
     color: $ms-color-white;
     height: 100%;
   }
+
   .ms-CommandButton-icon {
     color: $ms-color-white;
   }
@@ -118,7 +123,7 @@
   padding-left: 8px;
   line-height: 32px;
   color: $ms-color-neutralSecondary;
-  
+
   .ms-Icon {
     margin-right: 7px;
     font-size: $ms-font-size-l;
@@ -133,21 +138,21 @@
   border: 0;
   @include ms-bgColor-themeLighter;
   width: 208px;
-  
+
   .ms-SearchBox-field {
     border: 0;
     height: 40px;
     background: transparent;
     padding-left: 40px;
   }
-  
+
   .ms-SearchBox-label {
     display: block;
     line-height: 40px;
     height: 40px;
     padding-left: 0;
   }
-  
+
   .ms-SearchBox-icon {
     display: inline-block;
     width: 16px;
@@ -156,53 +161,53 @@
     margin-right: 8px;
     color: $ms-color-themePrimary;
   }
-  
+
   .ms-SearchBox-close {
     @include ms-bgColor-themeLighter;
     color: $ms-color-themePrimary;
-    
+
     .ms-CommandButton-icon {
       color: $ms-color-themePrimary;
     }
   }
-  
+
   &:hover {
     border: none;
     background-color: none;
-    
+
     .ms-SearchBox-label {
       color: $ms-color-neutralDark;
     }
-    
+
     .ms-SearchBox-icon {
       color: $ms-color-themePrimary;
     }
   }
-   
+
   &.is-collapsed {
     width: 50px;
     min-height: 40px;
-    
+
     .ms-SearchBox-close {
       display: none;
     }
-    
+
     .ms-SearchBox-text {
       display: none;
     }
   }
-  
+
   &.is-collapsed.is-active {
     width: 100%;
-    
+
     .ms-SearchBox-field {
       display: block;
     }
-    
+
     .ms-SearchBox-text {
       display: inline-block;
     }
-    
+
     .ms-SearchBox-close {
       display: block;
     }
@@ -211,21 +216,22 @@
 
 .ms-SearchBox.ms-SearchBox--commandBar.is-active {
    @include ms-bgColor-themeLight;
-   
+
    .ms-SearchBox-close {
     .ms-CommandButton-button {
       @include ms-bgColor-themeLight;
     }
    }
+
   .ms-SearchBox-label {
     display: block;
     line-height: 40px;
     height: 40px;
-    
+
     .ms-SearchBox-text {
       display: none;
     }
-    
+
     .ms-SearchBox-icon {
       width: 16px;
       margin-left: 16px;
@@ -234,8 +240,3 @@
     }
   }
 }
-
-
-
-
-  

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -172,7 +172,7 @@
   }
 
   &:hover {
-    border: none;
+    border: 0;
     background-color: none;
 
     .ms-SearchBox-label {

--- a/src/components/Spinner/Spinner.scss
+++ b/src/components/Spinner/Spinner.scss
@@ -29,7 +29,7 @@
 
 .ms-Spinner-label {
   position: relative;
-  @include ms-font-s();
+  @include ms-font-s;
   color: $ms-color-themePrimary;
   left: 28px;
   top: 2px;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -78,14 +78,16 @@
     border-bottom: 1px solid $ms-color-neutralLight;
   }
 
-  .ms-Table-rowCheck:after {
-    @include ms-Icon;
-    content: '\e041';
-    color: $ms-color-neutralTertiary;
-    font-size: 12px;
-    position: absolute;
-    left: 4px;
-    top: 9px;
+  .ms-Table-rowCheck {
+    &::after {
+      @include ms-Icon;
+      content: '\e041';
+      color: $ms-color-neutralTertiary;
+      font-size: 12px;
+      position: absolute;
+      left: 4px;
+      top: 9px;
+    }
   }
 }
 
@@ -117,6 +119,7 @@
       // A checkmark in a selected row.
       .ms-Table-rowCheck {
         background: none;
+
         // Show the checkbox.
         &:before {
           display: block;

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -193,7 +193,7 @@
   &:focus {
     border-color: $ms-color-themePrimary;
   }
-  
+
   .ms-TextField-field {
     border: 0;
     display: table-cell;

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -26,13 +26,13 @@
 
   &:hover {
     .ms-Label {
-      color: $ms-color-black; 
+      color: $ms-color-black;
     }
   }
 
   &:active {
-    .ms-Label { 
-      color: $ms-color-neutralPrimary; 
+    .ms-Label {
+      color: $ms-color-neutralPrimary;
     }
   }
 
@@ -41,6 +41,7 @@
     .ms-Label {
      @include ms-Label-is-disabled;
     }
+
     .ms-Toggle-field {
       background-color: $ms-color-white !important;
       border-color: $ms-color-neutralTertiaryAlt !important;
@@ -104,8 +105,8 @@
     }
   }
 
-  &:active { 
-    background-color: $ms-color-themePrimary; 
+  &:active {
+    background-color: $ms-color-themePrimary;
   }
 }
 
@@ -149,12 +150,12 @@
 
   &:focus,
   &:hover {
-    & + .ms-Toggle-field { 
-      background-color: $ms-color-neutralLight; 
+    & + .ms-Toggle-field {
+      background-color: $ms-color-neutralLight;
     }
-    
+
     &:checked + .ms-Toggle-field {
-      background-color: $ms-color-themeDark; 
+      background-color: $ms-color-themeDark;
     }
   }
 }


### PR DESCRIPTION
I've gone through and fixed most (over 400!) of the linting issues, which were primarily caused by empty spaces or missing new lines between selectors. I made some adjustments to the Sass linting settings which we'll want to review, either in this PR or before release. There are a lot of rules that are a matter of style so I leaned towards matching whatever I saw happening most often in our code.

There are two remaining warnings that we'll want to discuss:
1. The use of `!important`. We have this in Pivot and Toggle, and should see if we can remove it.
2. Only using `@extend` with [placeholder selectors](http://thesassway.com/intermediate/understanding-placeholder-selectors). This is a new Sass feature I'm unfamiliar with. We only have this error for one line of PersonaCard.

Note that the build will still fail due to TypeScript linting errors, which we can handle in another PR.