### PR TITLE
Fix TypeScript linting issues

### DIFF
--- a/src/components/AlignmentHost/AlignmentHost.ts
+++ b/src/components/AlignmentHost/AlignmentHost.ts
@@ -4,7 +4,8 @@
  * ContextualHost
  *
  * Hosts contextual menus and callouts
- * NOTE: Position bottom only works if html is set to max-height 100%, overflow hidden and body is set to overflow scroll, body is set to height 100%
+ * NOTE: Position bottom only works if html is set to max-height 100%, overflow
+ * hidden and body is set to overflow scroll, body is set to height 100%
  *
  */
 
@@ -24,29 +25,27 @@ namespace fabric {
 
   export class AlignmentHost {
 
-    private _contextualHost;
     private _alignmentClone;
     private _alignmentWidth;
     private _alignmentHeight;
     private _teWidth;
-    private _teHeight;
     private _direction;
     private _container;
     private _targetElement;
     private _matchTargetWidth;
     private _children;
-    
+
     constructor(children: Element, direction: string, targetElement: Element, matchTargetWidth?: boolean) {
       this._resizeAction = this._resizeAction.bind(this);
       this._disMissAction = this._disMissAction.bind(this);
       this._matchTargetWidth = matchTargetWidth || false;
       this._direction = direction;
-      
+
       this._children = children;
       this._container = this._createAlignmentContainer();
-      
+
       this._targetElement = targetElement;
-      
+
       this._openalignment();
       this._setResizeDisposal();
     }
@@ -56,7 +55,7 @@ namespace fabric {
       document.removeEventListener("click", this._disMissAction, true);
       this._alignmentClone.parentNode.removeChild(this._alignmentClone);
     }
-    
+
     private _createAlignmentContainer(): Element {
       let _aContainer = document.createElement("div");
       _aContainer.setAttribute("class", ALIGNMENT_CLASS);
@@ -69,7 +68,7 @@ namespace fabric {
 
     private _openalignment(): void {
       this._renderAlignment();
-      
+
       // this._savealignmentSize();
       this._findAvailablePosition();
       this._showalignment();
@@ -77,22 +76,22 @@ namespace fabric {
       // Delay the click setting
       setTimeout( () => { this._setDismissClick(); }, 100);
     }
-    
-    private _getAlignmentSize() {
-      switch(this._direction) {
-        case "left":
-          
-          break;
-        case "right":
-          break;
-        case "top":
-          break;
-        case "bottom":
-          break;
-        default:
-        this._setPosition();
-      }
-    }
+
+    // private _getAlignmentSize() {
+    //   switch (this._direction) {
+    //     case "left":
+
+    //       break;
+    //     case "right":
+    //       break;
+    //     case "top":
+    //       break;
+    //     case "bottom":
+    //       break;
+    //     default:
+    //     this._setPosition();
+    //   }
+    // }
 
     private _findAvailablePosition(): void {
       let _posOk;
@@ -182,9 +181,9 @@ namespace fabric {
       let mHLeft;
       let mHTop;
       let mWidth = "";
-      
-      if(this._matchTargetWidth) {
-        mWidth = "width: " + this._alignmentWidth + 'px;';
+
+      if (this._matchTargetWidth) {
+        mWidth = "width: " + this._alignmentWidth + "px;";
       }
 
       switch (curDirection) {
@@ -269,36 +268,36 @@ namespace fabric {
     private _renderAlignment(): void {
       document.body.appendChild(this._alignmentClone);
     }
-    
-    private _savealignmentSize(): void {
-      let _alignmentStyles = window.getComputedStyle(this._alignmentClone);
-      this._alignmentClone.setAttribute("style", "opacity: 0; z-index: -1");
-      this._alignmentClone.classList.add(ALIGNMENT_STATE_POSITIONED);
-      this._alignmentClone.classList.add(CONTEXT_STATE_CLASS);
-      
-      if(this._matchTargetWidth) {
-        let teStyles = window.getComputedStyle(this._targetElement);
-        this._alignmentWidth = this._targetElement.getBoundingClientRect().width
-          + (parseInt(teStyles.marginLeft, 10)
-          + parseInt(teStyles.marginLeft, 10));
-        // Set the ContextualHost width
-       
-      } else {
-        this._alignmentWidth = this._alignmentClone.getBoundingClientRect().width
-          + (parseInt(_alignmentStyles.marginLeft, 10)
-          + parseInt(_alignmentStyles.marginRight, 10));
-         this._alignmentClone.setAttribute("style", "");
-      }
-      
-      this._alignmentHeight = this._alignmentClone.getBoundingClientRect().height
-        + (parseInt(_alignmentStyles.marginTop, 10)
-        + parseInt(_alignmentStyles.marginBottom, 10));
-     
-      this._alignmentClone.classList.remove(ALIGNMENT_STATE_POSITIONED);
-      this._alignmentClone.classList.remove(CONTEXT_STATE_CLASS);
-      this._teWidth = this._targetElement.getBoundingClientRect().width;
-      this._teHeight = this._targetElement.getBoundingClientRect().height;
-    }
+
+    // private _savealignmentSize(): void {
+    //   let _alignmentStyles = window.getComputedStyle(this._alignmentClone);
+    //   this._alignmentClone.setAttribute("style", "opacity: 0; z-index: -1");
+    //   this._alignmentClone.classList.add(ALIGNMENT_STATE_POSITIONED);
+    //   this._alignmentClone.classList.add(CONTEXT_STATE_CLASS);
+
+    //   if (this._matchTargetWidth) {
+    //     let teStyles = window.getComputedStyle(this._targetElement);
+    //     this._alignmentWidth = this._targetElement.getBoundingClientRect().width
+    //       + (parseInt(teStyles.marginLeft, 10)
+    //       + parseInt(teStyles.marginLeft, 10));
+    //     // Set the ContextualHost width
+
+    //   } else {
+    //     this._alignmentWidth = this._alignmentClone.getBoundingClientRect().width
+    //       + (parseInt(_alignmentStyles.marginLeft, 10)
+    //       + parseInt(_alignmentStyles.marginRight, 10));
+    //      this._alignmentClone.setAttribute("style", "");
+    //   }
+
+    //   this._alignmentHeight = this._alignmentClone.getBoundingClientRect().height
+    //     + (parseInt(_alignmentStyles.marginTop, 10)
+    //     + parseInt(_alignmentStyles.marginBottom, 10));
+
+    //   this._alignmentClone.classList.remove(ALIGNMENT_STATE_POSITIONED);
+    //   this._alignmentClone.classList.remove(CONTEXT_STATE_CLASS);
+    //   this._teWidth = this._targetElement.getBoundingClientRect().width;
+    //   this._teHeight = this._targetElement.getBoundingClientRect().height;
+    // }
 
     private _disMissAction(e): void {
       // If the elemenet clicked is not INSIDE of searchbox then close seach

--- a/src/components/CommandBar/CommandBar.ts
+++ b/src/components/CommandBar/CommandBar.ts
@@ -75,8 +75,6 @@ namespace fabric {
     private searchBoxInstance: SearchBox;
     private _container: Element;
     private _commandButtonInstance: CommandButton;
-    
-    private _uiStateEvents: Array<Function> = [];
 
     constructor(container: Element) {
 
@@ -89,23 +87,23 @@ namespace fabric {
 
       this._setElements();
       this._setBreakpoint();
-      
+
       // If the overflow exists then run the overflow resizing
-      if(this._elements.overflowCommand) {
+      if (this._elements.overflowCommand) {
         this._initOverflow();
       }
       this._setUIState();
     }
-    
+
     private _runsSearchBox(reInit: boolean = true, state: string = "add") {
       this._changeSearchState("is-collapsed", state);
-      if(reInit) {
+      if (reInit) {
         this.searchBoxInstance = this._createSearchInstance();
       }
     }
-    
+
     private _runOverflow() {
-      if(this._elements.overflowCommand) {
+      if (this._elements.overflowCommand) {
         this._saveCommandWidths();
         this._redrawMenu();
         this._updateCommands();
@@ -113,7 +111,7 @@ namespace fabric {
         this._checkOverflow();
       }
     }
-    
+
     private _initOverflow() {
       this._createContextualRef();
       this._createItemCollection(this.itemCollection, CB_MAIN_AREA);
@@ -170,56 +168,56 @@ namespace fabric {
           break;
       }
     }
-      
+
     private _createSearchInstance(): any {
-      if(this._elements.searchBox) {
+      if (this._elements.searchBox) {
         return new fabric.SearchBox(<HTMLElement>this._elements.searchBox);
       } else {
         return false;
       }
     }
-    
+
     private _changeSearchState(state: string, action: string) {
-      if(this._elements.searchBox) {
+      if (this._elements.searchBox) {
         switch (action) {
           case "remove":
             this._elements.searchBox.classList.remove(state);
             break;
           case "add":
             this._elements.searchBox.classList.add(state);
+            break;
           default:
             break;
-        } 
+        }
       }
     }
-      
+
     private _setElements() {
       this._elements = {
         mainArea: this._container.querySelector(CB_MAIN_AREA)
       };
-      
-      if(this._container.querySelector(CB_SIDE_COMMAND_AREA)) {
+
+      if (this._container.querySelector(CB_SIDE_COMMAND_AREA)) {
         this._elements.sideCommandArea = this._container.querySelector(CB_SIDE_COMMAND_AREA);
       }
-      
-      if(this._container.querySelector(CB_ITEM_OVERFLOW)) {
+
+      if (this._container.querySelector(CB_ITEM_OVERFLOW)) {
         this._elements.overflowCommand = this._container.querySelector(CB_ITEM_OVERFLOW);
         this._elements.contextMenu = this._container.querySelector(CB_ITEM_OVERFLOW).querySelector(CONTEXTUAL_MENU);
       }
-      
-      if(this._container.querySelector(CB_MAIN_AREA + " " + CB_SEARCH_BOX)) {
+
+      if (this._container.querySelector(CB_MAIN_AREA + " " + CB_SEARCH_BOX)) {
          this._elements.searchBox = this._container.querySelector(CB_MAIN_AREA + " " + CB_SEARCH_BOX);
          this._elements.searchBoxClose = this._container.querySelector(SEARCH_BOX_CLOSE);
          this.searchBoxInstance = this._createSearchInstance();
       }
     }
-    
+
     private _createItemCollection(iCollection: Array<ItemCollection>, areaClass: string) {
       let item,
           label,
           iconClasses,
           splitClasses,
-          icon,
           items = this._container.querySelectorAll(areaClass + " " + COMMAND_BUTTON + ":not(" + CB_ITEM_OVERFLOW + ")");
 
       // Initiate the overflow command
@@ -229,8 +227,8 @@ namespace fabric {
         item = items[i];
         label = item.querySelector(COMMAND_BUTTON_LABEL).textContent;
         let icon = item.querySelector(ICON);
-        
-        if(icon) {
+
+        if (icon) {
             iconClasses = icon.className;
             splitClasses = iconClasses.split(" ");
         }
@@ -352,7 +350,7 @@ namespace fabric {
             thisItem.item.classList.remove(CB_NO_LABEL_CLASS);
           }
         }
-      }      
+      }
       for (let i = 0; i < this._sideAreaCollection.length; i++) {
         let thisItem = this._sideAreaCollection[i];
         if (!thisItem.isCollapsed) {

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -4,7 +4,8 @@
  * ContextualHost
  *
  * Hosts contextual menus and callouts
- * NOTE: Position bottom only works if html is set to max-height 100%, overflow hidden and body is set to overflow scroll, body is set to height 100%
+ * NOTE: Position bottom only works if html is set to max-height 100%, overflow hidden
+ * and body is set to overflow scroll, body is set to height 100%
  *
  */
 
@@ -32,7 +33,7 @@ namespace fabric {
     private _container;
     private _targetElement;
     private _matchTargetWidth;
-    
+
     constructor(container: HTMLElement, direction: string, targetElement: Element, matchTargetWidth?: boolean) {
       this._resizeAction = this._resizeAction.bind(this);
       this._disMissAction = this._disMissAction.bind(this);
@@ -150,9 +151,9 @@ namespace fabric {
       let mHLeft;
       let mHTop;
       let mWidth = "";
-      
-      if(this._matchTargetWidth) {
-        mWidth = "width: " + this._modalWidth + 'px;';
+
+      if (this._matchTargetWidth) {
+        mWidth = "width: " + this._modalWidth + "px;";
       }
 
       switch (curDirection) {
@@ -251,14 +252,14 @@ namespace fabric {
       this._modalClone.setAttribute("style", "opacity: 0; z-index: -1");
       this._modalClone.classList.add(MODAL_STATE_POSITIONED);
       this._modalClone.classList.add(CONTEXT_STATE_CLASS);
-      
-      if(this._matchTargetWidth) {
+
+      if (this._matchTargetWidth) {
         let teStyles = window.getComputedStyle(this._targetElement);
         this._modalWidth = this._targetElement.getBoundingClientRect().width
           + (parseInt(teStyles.marginLeft, 10)
           + parseInt(teStyles.marginLeft, 10));
         // Set the ContextualHost width
-       
+
       } else {
         this._modalWidth = this._modalClone.getBoundingClientRect().width
           + (parseInt(_modalStyles.marginLeft, 10)
@@ -268,7 +269,7 @@ namespace fabric {
       this._modalHeight = this._modalClone.getBoundingClientRect().height
         + (parseInt(_modalStyles.marginTop, 10)
         + parseInt(_modalStyles.marginBottom, 10));
-     
+
       this._modalClone.classList.remove(MODAL_STATE_POSITIONED);
       this._modalClone.classList.remove(CONTEXT_STATE_CLASS);
       this._teWidth = this._targetElement.getBoundingClientRect().width;

--- a/src/components/DatePicker/Jquery.DatePicker.ts
+++ b/src/components/DatePicker/Jquery.DatePicker.ts
@@ -68,8 +68,8 @@ namespace fabric {
           highlighted: "ms-DatePicker-day--highlighted",
           now: "ms-DatePicker-day--today",
           infocus: "ms-DatePicker-day--infocus",
-          outfocus: "ms-DatePicker-day--outfocus",
-        },
+          outfocus: "ms-DatePicker-day--outfocus"
+        }
       }, options || {}));
       let $picker = $dateField.pickadate("picker");
 
@@ -80,7 +80,7 @@ namespace fabric {
         },
         open: () => {
           this.scrollUp($datePicker);
-        },
+        }
       });
     }
 
@@ -279,7 +279,7 @@ namespace fabric {
     /** Scroll the page up so that the field the date picker is attached to is at the top. */
     public scrollUp($datePicker) {
       $("html, body").animate({
-        scrollTop: $datePicker.offset().top,
+        scrollTop: $datePicker.offset().top
       }, 367);
     }
   }

--- a/src/components/Dialog/jquery.Dialog.ts
+++ b/src/components/Dialog/jquery.Dialog.ts
@@ -16,6 +16,7 @@ namespace fabric {
      * @constructor
      */
     constructor(container: HTMLElement) {
+      // @TODO: Implement this.
     }
   } // end Dialog
 } // end Fabric namespace

--- a/src/components/DialogHost/DialogHost.ts
+++ b/src/components/DialogHost/DialogHost.ts
@@ -7,7 +7,7 @@ namespace fabric {
    * DialogHost class
    */
   export class DialogHost {
-    
+    // @TODO: Implement this.
   }
-  
+
 }

--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -19,14 +19,11 @@ namespace fabric {
      *
      * @param {HTMLElement} container - the target container for an instance of Dropdown
      * @constru
-    **/
+     */
     constructor(container: HTMLElement) {
-      
-      
-      
-      
+      // @TODO: Implement this component.
     }
-    
+
   }
-  
+
 }

--- a/src/components/Facepile/Facepile.ts
+++ b/src/components/Facepile/Facepile.ts
@@ -14,21 +14,21 @@ namespace fabric {
   const PERSONA_IMAGE = ".ms-Persona-image";
   const PERSONA_PRIMARY_CLASS = ".ms-Persona-primaryText";
   const PERSONA_SECONDARY_CLASS = ".ms-Persona-secondaryText";
-  
+
   interface PersonaCollection {
-    item: Element,
-    initials: string,
-    image: string,
-    primaryText: string,
-    secondaryText: string,
-    personaInstance: Persona
+    item: Element;
+    initials: string;
+    image: string;
+    primaryText: string;
+    secondaryText: string;
+    personaInstance: Persona;
   }
-  
+
   export class Facepile {
-    
+
     private _personaCollection: Array<PersonaCollection> = [];
     private _facePile: Element;
-    
+
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Facepile
@@ -38,27 +38,24 @@ namespace fabric {
       this._facePile = container;
       this._createPersonaCollection();
     }
-    
+
     private _createPersonaCollection() {
       let _personas = document.querySelectorAll(PERSONA_CLASS);
-      for(let i = 0; i < _personas.length; i++) {
+      for (let i = 0; i < _personas.length; i++) {
         let _thisPersona = _personas[i];
         this._personaCollection.push({
           item: _thisPersona,
           initials: _thisPersona.querySelector(PERSONA_INITIALS).textContent,
-          image:  _thisPersona.querySelector(PERSONA_IMAGE) ? 
+          image:  _thisPersona.querySelector(PERSONA_IMAGE) ?
           _thisPersona.querySelector(PERSONA_IMAGE).getAttribute("src") : null,
-          primaryText: _thisPersona.querySelector(PERSONA_PRIMARY_CLASS) ? 
+          primaryText: _thisPersona.querySelector(PERSONA_PRIMARY_CLASS) ?
           _thisPersona.querySelector(PERSONA_PRIMARY_CLASS).textContent : "",
-          secondaryText: _thisPersona.querySelector(PERSONA_SECONDARY_CLASS) ? 
+          secondaryText: _thisPersona.querySelector(PERSONA_SECONDARY_CLASS) ?
           _thisPersona.querySelector(PERSONA_SECONDARY_CLASS).textContent : "",
           personaInstance: new Persona(_thisPersona)
-        }); 
+        });
       }
     }
-    
-    private _registerClicks() {
-      
-    }
+
   }
 }

--- a/src/components/Overlay/Overlay.ts
+++ b/src/components/Overlay/Overlay.ts
@@ -8,11 +8,11 @@ namespace fabric {
    *
    */
   const OVERLAY_CLASS = "ms-Overlay";
-  
+
   export class Overlay {
-    overlayEl: Element;
-    _modifier: string;
-    
+    public overlayEl: Element;
+    private _modifier: string;
+
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Panel
@@ -22,8 +22,8 @@ namespace fabric {
       this._createElements();
       this._modifier = modifier || "";
     }
-    
-    _createElements() {
+
+    private _createElements() {
       this.overlayEl = document.createElement("div");
       this.overlayEl.classList.add(OVERLAY_CLASS);
       this.overlayEl.classList.add(this._modifier);

--- a/src/components/Panel/Panel.ts
+++ b/src/components/Panel/Panel.ts
@@ -17,7 +17,6 @@ namespace fabric {
 
     private _panel: Element;
     private _panelHost: PanelHost;
-    private _panelHostReference: Element;
     private _direction: string;
     private _animateOverlay: boolean;
 

--- a/src/components/Panel/Panel.ts
+++ b/src/components/Panel/Panel.ts
@@ -9,18 +9,18 @@ namespace fabric {
    * A host for the panel control
    *
    */
-  const ANIMATE_IN_STATE = 'animate-in';
-  const ANIMATE_OUT_STATE = 'animate-out';
+  const ANIMATE_IN_STATE = "animate-in";
+  const ANIMATE_OUT_STATE = "animate-out";
   const ANIMATION_END = 400;
-  
+
   export class Panel {
-    
-    _panel: Element
-    _panelHost: PanelHost;
-    _panelHostReference: Element;
-    _direction: string;
-    _animateOverlay: boolean;
-    
+
+    private _panel: Element;
+    private _panelHost: PanelHost;
+    private _panelHostReference: Element;
+    private _direction: string;
+    private _animateOverlay: boolean;
+
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Panel
@@ -33,19 +33,19 @@ namespace fabric {
       this._panelHost = new fabric.PanelHost(this._panel.cloneNode(true), this._animateInPanel);
       this._hideReferencePanel();
     }
-    
-    public dismiss() { 
+
+    public dismiss() {
       this._panel.classList.add(ANIMATE_OUT_STATE);
       setTimeout(function() {
         document.removeChild(this._panelHost);
         this._panelHost.dismiss();
       }, ANIMATION_END);
     }
-    
+
     private _animateInPanel(layer: Element) {
       layer.classList.add(ANIMATE_IN_STATE);
     }
-    
+
     private _hideReferencePanel() {
       this._panel.setAttribute("style", "display: none");
     }

--- a/src/components/PanelHost/PanelHost.ts
+++ b/src/components/PanelHost/PanelHost.ts
@@ -10,20 +10,14 @@ namespace fabric {
    *
    */
   const PANEL_HOST_CLASS = "ms-PanelHost";
-  const PANEL_HOST_INNER_CLASS = "ms-PanelHost-inner";
-  const PANE_ANIMATEIN_HOST_CLASS = "ms-u-fadeIn100";
-  const PANE_ANIMATEOUT_HOST_CLASS = "ms-u-fadeOut100";
-  
+
   export class PanelHost {
-    
+
     public panelHost: Element;
-    private _innerPanel: Element;
     private _overlay: Overlay;
-    private _direction: string;
-    private _animateOverlay: boolean;
     private _layer: Node;
     private _callBack: Function;
-    
+
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Panel
@@ -35,32 +29,32 @@ namespace fabric {
       this._createElements();
       this._renderElements();
     }
-    
+
     public dismiss() {
        document.removeChild(this.panelHost);
     }
-    
+
     public update(layer: Node, callBack?: Function) {
       this.panelHost.replaceChild(layer, this._layer);
-      
-      if(callBack) {
+
+      if (callBack) {
         callBack();
       }
     }
-    
+
     private _renderElements() {
       document.body.appendChild(this.panelHost);
       if (this._callBack) {
         this._callBack(this._layer);
       }
     }
-    
+
     private _createElements() {
       this.panelHost = document.createElement("div");
-      this.panelHost.classList.add(PANEL_HOST_CLASS)
+      this.panelHost.classList.add(PANEL_HOST_CLASS);
       this.panelHost.appendChild(this._layer);
       this._overlay = new fabric.Overlay();
-      
+
       // Append Elements
       this.panelHost.appendChild(this._overlay.overlayEl);
     }

--- a/src/components/PeoplePicker/PeoplePicker.ts
+++ b/src/components/PeoplePicker/PeoplePicker.ts
@@ -10,16 +10,15 @@ namespace fabric {
    * People picker control
    *
    */
-  const PEOPLE_PICKER_CLASS = "ms-PanelHost";
   const CONTEXT_CLASS = ".ms-ContextualHost";
   const MODAL_POSITION = "bottom";
-  
+
   export class PeoplePicker {
-    
+
     private _container: Element;
     private _contextualHostView: ContextualHost;
     private _contextualHost: Element;
-    
+
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of People Picker
@@ -30,20 +29,20 @@ namespace fabric {
       this._assignClicks();
       this._contextualHost = this._container.querySelector(CONTEXT_CLASS);
     }
-    
+
     private _createModalHost() {
       this._contextualHostView = new fabric.ContextualHost(
-        <HTMLElement>this._contextualHost, 
-        MODAL_POSITION, 
+        <HTMLElement>this._contextualHost,
+        MODAL_POSITION,
         this._container,
         true
       );
     }
-    
+
     private _clickHandler(e) {
       this._createModalHost();
     }
-    
+
     private _assignClicks() {
       this._container.addEventListener("click", this._clickHandler.bind(this), true);
     }

--- a/src/components/Persona/Persona.ts
+++ b/src/components/Persona/Persona.ts
@@ -10,16 +10,15 @@
 
 namespace fabric {
 
-  const PERSONA_CLASS = ".ms-Persona";
   const CONTEXTUAL_HOST_CLASS = ".ms-ContextualHost";
   const MODAL_POSITION = "top";
-  
+
   export class Persona {
-    
-    _persona: Element;
-    _contextualHost: Element;
-    _contextualHostInstance: ContextualHost;
-    
+
+    private _persona: Element;
+    private _contextualHost: Element;
+    private _contextualHostInstance: ContextualHost;
+
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Facepile
@@ -27,22 +26,22 @@ namespace fabric {
      */
     constructor(container: Element) {
       this._persona = container;
-      //If Persona Card and Contextual host exist continue
+      // If Persona Card and Contextual host exist continue
       this._contextualHost = this._persona.querySelector(CONTEXTUAL_HOST_CLASS);
-      
-      if(this._contextualHost) {
+
+      if (this._contextualHost) {
         this._assignEvents();
       }
     }
-    
+
     private _createContextualHostInstance() {
       this._contextualHostInstance = new fabric.ContextualHost(<HTMLElement>this._contextualHost, MODAL_POSITION, this._persona);
     }
-    
+
     private _personaEventHandler() {
       this._createContextualHostInstance();
     }
-    
+
     private _assignEvents() {
       this._persona.addEventListener("click", this._personaEventHandler.bind(this), false);
     }

--- a/src/components/PersonaCard/PersonaCard.ts
+++ b/src/components/PersonaCard/PersonaCard.ts
@@ -35,7 +35,7 @@ namespace fabric {
       this._actions.removeEventListener("click", this._onActionClick.bind(this));
       this._expander.removeEventListener("click", this._onExpanderClick.bind(this));
     }
-    
+
     private _onExpanderClick(event: Event): void {
       const parent: HTMLElement = (<HTMLElement>event.target).parentElement;
       if (parent.classList.contains("is-collapsed")) {
@@ -43,7 +43,7 @@ namespace fabric {
       } else {
         parent.classList.add("is-collapsed");
       }
-      //$(this).parent(".ms-PersonaCard-actionDetails").toggleClass("is-collapsed");
+      // $(this).parent(".ms-PersonaCard-actionDetails").toggleClass("is-collapsed");
     }
 
     private _onActionClick(event: Event): void {

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-inferrable-types": true,
+    "no-inferrable-types": false,
     "no-shadowed-variable": true,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,


### PR DESCRIPTION
Went through and fixed all of the TypeScript linting errors and warnings, most of which were related to whitespace or not specifically declaring variables as public or private. I also commented out some unused functions (these should be reviewed and removed if they won't be used) and removed unused variables.

The only change I've made to the linting rules is to allow 'inferable types', such as `boolean = true`. It's not strictly necessary to provide a type for these but VSCode shows an error without a type. I also don't see the harm in being very explicit about what type is desired.