### PR TITLE
Fix Sass linting warnings by removing !important and @extend

### DIFF
--- a/src/components/PersonaCard/PersonaCard.scss
+++ b/src/components/PersonaCard/PersonaCard.scss
@@ -36,7 +36,8 @@
   height: 48px;
 }
 
-.ms-PersonaCard-action {
+.ms-PersonaCard-action,
+.ms-PersonaCard-overflow {
   display: inline-block;
   cursor: pointer;
   font-size: $ms-font-size-l;
@@ -89,7 +90,6 @@
 }
 
 .ms-PersonaCard-overflow {
-  @extend .ms-PersonaCard-action;
   font-size: $ms-font-size-m;
   color: $ms-color-neutralPrimary;
   float: right;

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -54,7 +54,7 @@
   }
 
   &:active {
-    color: $ms-color-themePrimary !important;
+    color: $ms-color-themePrimary;
   }
 }
 
@@ -103,7 +103,7 @@
     }
 
     &:active {
-      color: $ms-color-white !important;
+      color: $ms-color-white;
       background-color: $ms-color-themePrimary;
     }
 
@@ -122,7 +122,7 @@
     }
 
     &:active {
-      background-color: $ms-color-themePrimary !important;
+      background-color: $ms-color-themePrimary;
     }
   }
 }

--- a/src/components/Toggle/Toggle.md
+++ b/src/components/Toggle/Toggle.md
@@ -9,6 +9,9 @@ Allows for turning on or off a setting. This is best suited for simple, singular
 ### Label on left
 @@include('Toggle.TextLeft.html')
 
+### Disabled
+@@include('Toggle.Disabled.html')
+
 ## Using this component
 1. Confirm that you have references to Fabric's CSS on your page:
     ```

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -43,13 +43,13 @@
     }
 
     .ms-Toggle-field {
-      background-color: $ms-color-white !important;
-      border-color: $ms-color-neutralTertiaryAlt !important;
-      pointer-events: none !important;
-      cursor: default !important;
+      background-color: $ms-color-white;
+      border-color: $ms-color-neutralTertiaryAlt;
+      pointer-events: none;
+      cursor: default;
 
       &:before {
-        background-color: $ms-color-neutralTertiaryAlt !important;
+        background-color: $ms-color-neutralTertiaryAlt;
       }
     }
 
@@ -174,7 +174,7 @@
 
     @media screen and (-ms-high-contrast: black-on-white) {
       background-color: $ms-color-black;
-    }    
+    }
   }
 
   &:focus,


### PR DESCRIPTION
This PR fixes the remaining Sass linting warnings by removing `!important` from Pivot and Toggle. I've tested these (screenshots below) and they display fine without the extra specificity.

Also removed `@extend` from PersonaCard, as this was resulting in a linting warning and we get the equivalent output with a simple selector.

![screen shot 2016-05-13 at 9 36 28 am](https://cloud.githubusercontent.com/assets/1382445/15255308/211df062-18f0-11e6-8972-06782c05ac6e.png)
![screen shot 2016-05-13 at 9 39 26 am](https://cloud.githubusercontent.com/assets/1382445/15255316/293e5f8e-18f0-11e6-9fc6-44bc521d167e.png)
