### PR TITLE
Update how text properties are set for components

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.scss
+++ b/src/components/Breadcrumb/Breadcrumb.scss
@@ -7,6 +7,7 @@
 
 
 .ms-Breadcrumb {
+  font-family: $ms-font-family-base;
   margin: 23px 0 1px;
 
   &.is-overflow {
@@ -119,7 +120,9 @@
 }
 
 .ms-Breadcrumb-itemLink {
-  @include ms-font-xl;
+  font-weight: $ms-font-weight-light;
+  font-size: $ms-font-size-xl;
+  color: $ms-color-neutralPrimary;
   display: inline-block;
   padding: 0 4px;
   max-width: 160px;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -7,112 +7,115 @@
 
 
 .ms-Button {
-	@include ms-font-m;
-	@include ms-u-normalize;
-	background-color: $ms-color-neutralLighter;
-	border: 1px solid $ms-color-neutralLighter;
-	cursor: pointer;
-	display: inline-block;
-	height: 32px;
-	min-width: 80px;
-	padding: 4px 20px 6px;
+  @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
+  background-color: $ms-color-neutralLighter;
+  border: 1px solid $ms-color-neutralLighter;
+  cursor: pointer;
+  display: inline-block;
+  height: 32px;
+  min-width: 80px;
+  padding: 4px 20px 6px;
 
-	&:hover {
-		background-color: $ms-color-neutralLight;
-		border-color: $ms-color-neutralLight;
-		outline: 1px solid transparent;
+  &:hover {
+    background-color: $ms-color-neutralLight;
+    border-color: $ms-color-neutralLight;
+    outline: 1px solid transparent;
 
-		.ms-Button-label {
-			color: $ms-color-black;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-black;
+    }
+  }
 
-	&:focus {
-		background-color: $ms-color-neutralLight;
-		border-color: $ms-color-themePrimary;
-		outline: 1px solid transparent;
+  &:focus {
+    background-color: $ms-color-neutralLight;
+    border-color: $ms-color-themePrimary;
+    outline: 1px solid transparent;
 
-		.ms-Button-label {
-			color: $ms-color-black;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-black;
+    }
+  }
 
-	&:active {
-		background-color: $ms-color-themePrimary;
-		border-color: $ms-color-themePrimary;
+  &:active {
+    background-color: $ms-color-themePrimary;
+    border-color: $ms-color-themePrimary;
 
-		.ms-Button-label {
-			color: $ms-color-white;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-white;
+    }
+  }
 
-	&:disabled,
-	&.is-disabled {
-		background-color: $ms-color-neutralLighter;
-		border-color: $ms-color-neutralLighter;
-		cursor: default;
+  &:disabled,
+  &.is-disabled {
+    background-color: $ms-color-neutralLighter;
+    border-color: $ms-color-neutralLighter;
+    cursor: default;
 
-		.ms-Button-label {
-			color: $ms-color-neutralTertiary;
-		}
+    .ms-Button-label {
+      color: $ms-color-neutralTertiary;
+    }
 
-		&:hover,
-		&:focus {
-			outline: 0;
-		}
-	}
+    &:hover,
+    &:focus {
+      outline: 0;
+    }
+  }
 }
 
 // Add space between adjacent buttons.
 .ms-Button + .ms-Button {
-	margin-left: 6px;
+  margin-left: 6px;
 }
 
 .ms-Button-label {
-	color: $ms-color-neutralPrimary;
-	font-family: $ms-font-family-semibold;
-	font-size: $ms-font-size-m;
+  color: $ms-color-neutralPrimary;
+  font-weight: $ms-font-weight-semibold;
+  font-size: $ms-font-size-m;
 }
 
 .ms-Button-icon,
 .ms-Button-description {
-	display: none;
+  display: none;
 }
 
 //== Modifier: Primary action button
 //
 .ms-Button.ms-Button--primary {
-	background-color: $ms-color-themePrimary;
-	border-color: $ms-color-themePrimary;
+  background-color: $ms-color-themePrimary;
+  border-color: $ms-color-themePrimary;
 
-	.ms-Button-label {
-		color: $ms-color-white;
-	}
+  .ms-Button-label {
+    color: $ms-color-white;
+  }
 
-	&:hover {
-		background-color: $ms-color-themeDark;
-		border-color: $ms-color-themeDark;
-	}
+  &:hover {
+    background-color: $ms-color-themeDark;
+    border-color: $ms-color-themeDark;
+  }
 
-	&:focus {
-		background-color: $ms-color-themeDark;
-		border-color: $ms-color-themeDarker;
-	}
+  &:focus {
+    background-color: $ms-color-themeDark;
+    border-color: $ms-color-themeDarker;
+  }
 
-	&:active {
-		background-color: $ms-color-themePrimary;
-		border-color: $ms-color-themePrimary;
-	}
+  &:active {
+    background-color: $ms-color-themePrimary;
+    border-color: $ms-color-themePrimary;
+  }
 
-	&:disabled,
-	&.is-disabled {
-		background-color: $ms-color-neutralLighter;
-		border-color: $ms-color-neutralLighter;
+  &:disabled,
+  &.is-disabled {
+    background-color: $ms-color-neutralLighter;
+    border-color: $ms-color-neutralLighter;
 
-		.ms-Button-label {
-			color: $ms-color-neutralTertiary;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-neutralTertiary;
+    }
+  }
 }
 
 
@@ -143,125 +146,125 @@
     }
   }
 
-	.ms-Button-label {
-		color: $ms-color-themePrimary;
-		font-family: $ms-font-family-light;
-		font-size: $ms-font-size-xl;
-		position: relative;
-		top: -5px;
-		text-decoration: none;
-	}
+  .ms-Button-label {
+    color: $ms-color-themePrimary;
+    font-weight: $ms-font-weight-light;
+    font-size: $ms-font-size-xl;
+    position: relative;
+    top: -5px;
+    text-decoration: none;
+  }
 
-	&:hover,
-	&:focus {
-		.ms-Button-icon {
-			.ms-Icon {
-				color: $ms-color-themeDark;
-			}
-		}
+  &:hover,
+  &:focus {
+    .ms-Button-icon {
+      .ms-Icon {
+        color: $ms-color-themeDark;
+      }
+    }
 
-		.ms-Button-label {
-			color: $ms-color-themeDarker;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-themeDarker;
+    }
+  }
 
-	&:active {
-		.ms-Button-icon {
-			.ms-Icon {
-				color: $ms-color-themePrimary;
-			}
-		}
+  &:active {
+    .ms-Button-icon {
+      .ms-Icon {
+        color: $ms-color-themePrimary;
+      }
+    }
 
-		.ms-Button-label {
-			color: $ms-color-themePrimary;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-themePrimary;
+    }
+  }
 
-	&:disabled,
-	&.is-disabled {
-		.ms-Button-icon {
-			.ms-Icon {
-				color: $ms-color-neutralTertiaryAlt;
-			}
-		}
+  &:disabled,
+  &.is-disabled {
+    .ms-Button-icon {
+      .ms-Icon {
+        color: $ms-color-neutralTertiaryAlt;
+      }
+    }
 
-		.ms-Button-label {
-			color: $ms-color-neutralTertiary;
-		}
-	}
+    .ms-Button-label {
+      color: $ms-color-neutralTertiary;
+    }
+  }
 }
 
 
 //== Modifier: Compound button
 //
 .ms-Button.ms-Button--compound {
-	height: auto;
-	min-height: 72px;
-	max-width: 280px;
-	padding: 20px;
+  height: auto;
+  min-height: 72px;
+  max-width: 280px;
+  padding: 20px;
 
-	.ms-Button-label {
-		display: block;
-		font-family: $ms-font-family-semibold;
-		position: relative;
-		text-align: left;
-		margin-top: -5px;
-	}
+  .ms-Button-label {
+    display: block;
+    font-weight: $ms-font-weight-semibold;
+    position: relative;
+    text-align: left;
+    margin-top: -5px;
+  }
 
-	.ms-Button-description {
-		color: $ms-color-neutralSecondary;
-		display: block;
-		font-family: $ms-font-family-regular;
-		font-size: $ms-font-size-s;
-		position: relative;
-		text-align: left;
-		top: 3px;
-	}
+  .ms-Button-description {
+    color: $ms-color-neutralSecondary;
+    display: block;
+    font-weight: $ms-font-weight-regular;
+    font-size: $ms-font-size-s;
+    position: relative;
+    text-align: left;
+    top: 3px;
+  }
 
-	&:hover {
-		.ms-Button-description {
-			color: $ms-color-neutralDark;
-		}
-	}
+  &:hover {
+    .ms-Button-description {
+      color: $ms-color-neutralDark;
+    }
+  }
 
-	&:focus {
-		border-color: $ms-color-themePrimary;
-		background-color: $ms-color-neutralLighter;
+  &:focus {
+    border-color: $ms-color-themePrimary;
+    background-color: $ms-color-neutralLighter;
 
-		.ms-Button-label {
-			color: $ms-color-neutralPrimary;
-		}
+    .ms-Button-label {
+      color: $ms-color-neutralPrimary;
+    }
 
-		.ms-Button-description {
-			color: $ms-color-neutralSecondary;
-		}
-	}
+    .ms-Button-description {
+      color: $ms-color-neutralSecondary;
+    }
+  }
 
-	&:active {
-		background-color: $ms-color-themePrimary;
+  &:active {
+    background-color: $ms-color-themePrimary;
 
-		.ms-Button-description,
-		.ms-Button-label {
-			color: $ms-color-white;
-		}
-	}
+    .ms-Button-description,
+    .ms-Button-label {
+      color: $ms-color-white;
+    }
+  }
 
-	&:disabled,
-	&.is-disabled {
-		.ms-Button-label,
-		.ms-Button-description {
-			color: $ms-color-neutralTertiary;
-		}
+  &:disabled,
+  &.is-disabled {
+    .ms-Button-label,
+    .ms-Button-description {
+      color: $ms-color-neutralTertiary;
+    }
 
-		&:focus,
-		&:active {
-			border-color: $ms-color-neutralLighter;
-			background-color: $ms-color-neutralLighter;
+    &:focus,
+    &:active {
+      border-color: $ms-color-neutralLighter;
+      background-color: $ms-color-neutralLighter;
 
-			.ms-Button-label,
-			.ms-Button-description {
-				color: $ms-color-neutralTertiary;
-			}
-		}
-	}
+      .ms-Button-label,
+      .ms-Button-description {
+        color: $ms-color-neutralTertiary;
+      }
+    }
+  }
 }

--- a/src/components/Callout/Callout.scss
+++ b/src/components/Callout/Callout.scss
@@ -9,6 +9,7 @@ $ms-Callout-commandButtonHeight: 27px;
 
 .ms-Callout {
   width: 288px;
+  font-family: $ms-font-family-base;
 }
 
 .ms-Callout-header {
@@ -18,13 +19,13 @@ $ms-Callout-commandButtonHeight: 27px;
 
 .ms-Callout-title {
   margin: 0;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-xl;
 }
 
 .ms-Callout-subText {
   margin: 0;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   color: $ms-color-neutralPrimary;
   font-size: $ms-font-size-s;
 }
@@ -95,7 +96,7 @@ $ms-Callout-commandButtonHeight: 27px;
   }
 
   .ms-Callout-title {
-    font-family: $ms-font-family-light;
+    font-weight: $ms-font-weight-light;
     font-size: $ms-font-size-xxl;
     color: $ms-color-white;
   }

--- a/src/components/ChoiceField/ChoiceField.scss
+++ b/src/components/ChoiceField/ChoiceField.scss
@@ -8,121 +8,124 @@
 
 // Unselected, radio button (default)
 .ms-ChoiceField {
-	@include ms-font-m;
-	@include ms-u-normalize;
-	min-height: 36px;
-	position: relative;
+  @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
+  min-height: 36px;
+  position: relative;
 
-	.ms-Label {
-		font-size: $ms-font-size-m;
-		padding: 0 0 0 26px;
-	}
+  .ms-Label {
+    font-size: $ms-font-size-m;
+    padding: 0 0 0 26px;
+  }
 
-	// disabled
-	& .ms-ChoiceField-field.is-disabled {
-		pointer-events: none;
-		cursor: default;
+  // disabled
+  & .ms-ChoiceField-field.is-disabled {
+    pointer-events: none;
+    cursor: default;
 
-		&:before {
-			background-color: $ms-color-neutralTertiaryAlt;
-			color: $ms-color-neutralTertiaryAlt;
-		}
+    &:before {
+      background-color: $ms-color-neutralTertiaryAlt;
+      color: $ms-color-neutralTertiaryAlt;
+    }
 
-		&:after {
-			border-color: $ms-color-neutralLight;
-		}
+    &:after {
+      border-color: $ms-color-neutralLight;
+    }
 
-		.ms-Label {
-			color: $ms-color-neutralTertiary;
-		}
-	}
+    .ms-Label {
+      color: $ms-color-neutralTertiary;
+    }
+  }
 
-	& .ms-ChoiceField-field.in-focus:after {
-		border-color: $ms-color-neutralSecondaryAlt;
-	}
+  & .ms-ChoiceField-field.in-focus:after {
+    border-color: $ms-color-neutralSecondaryAlt;
+  }
 }
 
 // The original unstyled input element
 .ms-ChoiceField-input {
-	position: absolute;
-	opacity: 0;
-	top: 8px;
+  position: absolute;
+  opacity: 0;
+  top: 8px;
 }
 
 // The choicefield radio button or checkbox
 .ms-ChoiceField-field {
-	display: inline-block;
-	cursor: pointer;
-	margin-top: 8px;
-	position: relative;
+  display: inline-block;
+  cursor: pointer;
+  margin-top: 8px;
+  position: relative;
 
-	// The actual styled choicefield element - radio button by default
-	&:after {
-		content: '';
-		display: inline-block;
-		border: 1px $ms-color-neutralTertiaryAlt solid;
-		width: 19px;
-		height: 19px;
-		cursor: pointer;
-		font-weight: normal;
-		left: -1px;
-		top: -1px;
-		border-radius: 50%;
-		position: absolute;
-	}
+  // The actual styled choicefield element - radio button by default
+  &:after {
+    content: '';
+    display: inline-block;
+    border: 1px $ms-color-neutralTertiaryAlt solid;
+    width: 19px;
+    height: 19px;
+    cursor: pointer;
+    font-weight: normal;
+    left: -1px;
+    top: -1px;
+    border-radius: 50%;
+    position: absolute;
+  }
 
-	&:hover {
-		&:after {
-			border-color: $ms-color-neutralSecondaryAlt;
-		}
+  &:hover {
+    &:after {
+      border-color: $ms-color-neutralSecondaryAlt;
+    }
 
-		.ms-Label {
-			color: $ms-color-black;
-		}
-	}
+    .ms-Label {
+      color: $ms-color-black;
+    }
+  }
 
-	&.ms-ChoiceField-type--checkbox {
-		&:after {
-			border-radius: 0;
-		}
+  &.ms-ChoiceField-type--checkbox {
+    &:after {
+      border-radius: 0;
+    }
 
-		&.is-checked {
-			&:hover:before,
-			&:before {
-				@include ms-Icon;
-				content: '\e041';
-				background-color: transparent;
-				border-radius: 0;
-				font-size: $ms-font-size-s-plus;
-				top: 3px;
-				left: 3px;
-			}
-		}
-	}
+    &.is-checked {
+      &:hover:before,
+      &:before {
+        @include ms-Icon;
+        content: '\e041';
+        background-color: transparent;
+        border-radius: 0;
+        font-size: $ms-font-size-s-plus;
+        top: 3px;
+        left: 3px;
+      }
+    }
+  }
 
-	// Radio button by default
-	&.is-checked {
-		// Circle indicating a checked radio button
-		&:before {
-			background-color: $ms-color-neutralSecondary;
-			border-color: $ms-color-neutralSecondary;
-			color: $ms-color-neutralSecondary;
-			border-radius: 50%;
-			content: '\00a0';
-			display: inline-block;
-			position: absolute;
-			top: 4px;
-			right: 0;
-			bottom: 0;
-			left: 4px;
-			width: 11px;
-			height: 11px;
-			box-sizing: border-box;
-		}
+  // Radio button by default
+  &.is-checked {
+    // Circle indicating a checked radio button
+    &:before {
+      background-color: $ms-color-neutralSecondary;
+      border-color: $ms-color-neutralSecondary;
+      color: $ms-color-neutralSecondary;
+      border-radius: 50%;
+      content: '\00a0';
+      display: inline-block;
+      position: absolute;
+      top: 4px;
+      right: 0;
+      bottom: 0;
+      left: 4px;
+      width: 11px;
+      height: 11px;
+      box-sizing: border-box;
+    }
 
-		&:hover:before {
-			background-color: $ms-color-neutralDark;
-			color: $ms-color-neutralDark;
-		}
-	}
+    &:hover:before {
+      background-color: $ms-color-neutralDark;
+      color: $ms-color-neutralDark;
+    }
+  }
 }

--- a/src/components/ChoiceFieldGroup/ChoiceFieldGroup.scss
+++ b/src/components/ChoiceFieldGroup/ChoiceFieldGroup.scss
@@ -2,5 +2,6 @@
 //
 // Choice field groups contain multiple radio buttons or checkboxes
 .ms-ChoiceFieldGroup {
-	margin-bottom: 4px;
+  margin-bottom: 4px;
+  font-family: $ms-font-family-base;
 }

--- a/src/components/CommandBar/CommandBar.scss
+++ b/src/components/CommandBar/CommandBar.scss
@@ -22,6 +22,7 @@ $CommandBarItem-height: $CommandBar-height;
   padding-left: 0;
   border: 0;
   position: relative;
+  font-family: $ms-font-family-base;
 
   &:focus {
     outline: none;

--- a/src/components/CommandButton/CommandButton.scss
+++ b/src/components/CommandButton/CommandButton.scss
@@ -11,13 +11,14 @@ $CommandButton-padding: 8px;
 .ms-CommandButton {
   display: inline-block;
   position: relative;
+  font-family: $ms-font-family-base;
 
   &.is-hidden {
     display: none;
   }
 
   &:disabled,
-	&.is-disabled {
+  &.is-disabled {
     .ms-CommandButton-button {
       cursor: default;
 
@@ -62,13 +63,16 @@ $CommandButton-padding: 8px;
 }
 
 @mixin ms-CommandBarButton-buttonBase {
-  @include ms-font-m;
-	@include ms-u-normalize;
-	// background-color: $ms-color-themeLighterAlt;
-	// border: 1px solid $ms-color-themeLighterAlt;
-	cursor: pointer;
-	display: inline-block;
-	height: $CommandButton-height;
+  @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
+  // background-color: $ms-color-themeLighterAlt;
+  // border: 1px solid $ms-color-themeLighterAlt;
+  cursor: pointer;
+  display: inline-block;
+  height: $CommandButton-height;
   line-height: $CommandButton-height;
   outline: 1px solid transparent;
   padding: 0 $CommandButton-padding;
@@ -80,13 +84,13 @@ $CommandButton-padding: 8px;
     background-color: $ms-color-themeLight;
 
     .ms-CommandButton-label {
-			color: $ms-color-neutralDark;
-		}
-	}
+      color: $ms-color-neutralDark;
+    }
+  }
 
-	&:focus::before {
-		@include  ms-CommandBar-focusRectangle;
-	}
+  &:focus::before {
+    @include  ms-CommandBar-focusRectangle;
+  }
 
   &:focus {
     outline: 0;
@@ -105,7 +109,7 @@ $CommandButton-padding: 8px;
 
 // Add space between adjacent command buttons.
 .ms-CommandButton + .ms-CommandButton {
-	margin-left: 8px;
+  margin-left: 8px;
 }
 
 .ms-CommandButton-icon {
@@ -122,7 +126,9 @@ $CommandButton-padding: 8px;
 }
 
 .ms-CommandButton-label {
-  @include ms-font-m;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   color: $ms-color-neutralPrimary;
   line-height: $CommandButton-height;
   height: 100%;
@@ -137,7 +143,10 @@ $CommandButton-padding: 8px;
 .ms-CommandButton-dropdownIcon {
   display: inline-block;
   position: relative;
-  @include ms-font-l;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-l;
+  font-weight: $ms-font-weight-semilight;
   min-width: 17px;
   height: 100%;
 
@@ -151,7 +160,10 @@ $CommandButton-padding: 8px;
 }
 
 .ms-CommandButton-splitIcon {
-  @include ms-font-l;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-l;
+  font-weight: $ms-font-weight-semilight;
   margin-left: -4px;
   width: 21px;
   border: 0;
@@ -224,7 +236,7 @@ $CommandButton-padding: 8px;
     &::before {
       @include ms-CommandButton-pivotLine;
     }
-	}
+  }
 }
 
 .ms-CommandButton.ms-CommandButton--textOnly,

--- a/src/components/ContextualHost/ContextualHost.scss
+++ b/src/components/ContextualHost/ContextualHost.scss
@@ -4,6 +4,7 @@
   position: relative;
   min-width: 10px;
   display: none;
+  font-family: $ms-font-family-base;
 
   &.is-positioned {
     position: absolute;

--- a/src/components/ContextualMenu/ContextualMenu.scss
+++ b/src/components/ContextualMenu/ContextualMenu.scss
@@ -7,8 +7,11 @@
 
 
 .ms-ContextualMenu {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   display: block;
   min-width: 180px;
   list-style-type: none;
@@ -33,7 +36,7 @@
   &.is-selected {
     background-color: $ms-color-themeLight;
     color: $ms-color-black;
-    font-family: $ms-font-family-semibold;
+    font-weight: $ms-font-weight-semibold;
 
     &:hover {
       background-color: $ms-color-themeLight;

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -9,6 +9,7 @@
 .ms-DatePicker {
   @include ms-u-normalize;
   margin-bottom: 17px;
+  font-family: $ms-font-family-base;
   z-index: $ms-zIndex-DatePicker;
 
   .ms-TextField { position: relative; }
@@ -92,7 +93,7 @@
 .ms-DatePicker-month,
 .ms-DatePicker-year {
   display: inline-block;
-  font-family: $ms-font-family-light;
+  font-weight: $ms-font-weight-light;
   font-size: 21px;
   color: $ms-color-themePrimary;
   margin-top: -1px;
@@ -136,9 +137,8 @@
   height: 40px;
   padding: 0;
   line-height: 40px;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
   font-size: 15px;
-  font-weight: normal;
   color: $ms-color-neutralPrimary;
 }
 
@@ -159,7 +159,7 @@
 // Out of focus days.
 .ms-DatePicker-day--outfocus {
   color: $ms-color-neutralTertiary;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
 }
 
 
@@ -251,8 +251,7 @@
 .ms-DatePicker-currentYear,
 .ms-DatePicker-currentDecade {
   display: block;
-  font-weight: normal;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: 21px;
   height: 40px;
   line-height: 42px;
@@ -289,8 +288,7 @@
   cursor: pointer;
   float: left;
   margin: 0 10px 10px 0;
-  font-weight: normal;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
   font-size: 13px;
   color: $ms-color-neutralPrimary;
   text-align: center;
@@ -312,7 +310,7 @@
   bottom: 9px;
   color: $ms-color-themePrimary;
   cursor: pointer;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: 13px;
   height: 30px;
   line-height: 30px;
@@ -359,7 +357,7 @@
   // Update header text styles.
   .ms-DatePicker-month,
   .ms-DatePicker-year {
-    font-family: $ms-font-family-semilight;
+    font-weight: $ms-font-weight-semilight;
     font-size: 17px;
     color: $ms-color-neutralPrimary;
 
@@ -419,7 +417,7 @@
     width: 30px;
     height: 30px;
     line-height: 30px;
-    font-family: $ms-font-family-semibold;
+    font-weight: $ms-font-weight-semibold;
     font-size: 12px;
   }
 

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -15,6 +15,7 @@
 .ms-Dialog {
   height: auto;
   padding: 0 20px 20px;
+  font-family: $ms-font-family-base;
 }
 
 // Close button, hidden by default
@@ -45,7 +46,7 @@
 
 .ms-Dialog-title {
   margin: 0;
-  font-family: $ms-font-family-light;
+  font-weight: $ms-font-weight-light;
   font-size: $ms-font-size-xl;
 }
 
@@ -62,7 +63,7 @@
 .ms-Dialog-subText {
   margin: 0 0 20px;
   padding-top: 8px;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   color: $ms-color-neutralPrimary;
   font-size: $ms-font-size-s;
 }
@@ -135,7 +136,7 @@
 
   .ms-Dialog-title {
     font-size: $ms-font-size-xxl;
-    font-family: $ms-font-family-light;
+    font-weight: $ms-font-weight-light;
     color: $ms-color-white;
   }
 

--- a/src/components/DialogHost/DialogHost.scss
+++ b/src/components/DialogHost/DialogHost.scss
@@ -7,4 +7,5 @@
   position: relative;
   text-align: left;
   outline: 1px solid transparent;
+  font-family: $ms-font-family-base;
 }

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -25,8 +25,11 @@
 }
 
 .ms-Dropdown {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   margin-bottom: 10px;
   position: relative;
   outline: 0;

--- a/src/components/Facepile/Facepile.scss
+++ b/src/components/Facepile/Facepile.scss
@@ -10,6 +10,7 @@
   position: relative;
   height: 32px;
   width: auto;
+  font-family: $ms-font-family-base;
 
   .ms-Facepile-personaCardHost {
     display: none;
@@ -93,7 +94,7 @@
   }
 
   .ms-PeoplePicker-selectedHeader {
-    font-family: $ms-font-family-light;
+    font-weight: $ms-font-weight-light;
     font-size: $ms-font-size-xl;
     color: $ms-color-neutralPrimary;
     line-height: 82px;

--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -18,17 +18,20 @@
 
 
 .ms-Label {
-	@include ms-font-s;
-	@include ms-u-normalize;
-	box-sizing: border-box;
-	display: block;
-	padding: 5px 0;
+  @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-s;
+  font-weight: $ms-font-weight-regular;
+  box-sizing: border-box;
+  display: block;
+  padding: 5px 0;
 
-	&.is-required {
-		@include ms-Label-is-required;
-	}
+  &.is-required {
+    @include ms-Label-is-required;
+  }
 
-	&.is-disabled {
-		 @include ms-Label-is-disabled;
-	}
+  &.is-disabled {
+     @include ms-Label-is-disabled;
+  }
 }

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -7,7 +7,9 @@
 
 
 @mixin ms-Link {
-  @include ms-font-m;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   color: $ms-color-themePrimary;
   text-decoration: none;
   cursor: pointer;

--- a/src/components/List/List.scss
+++ b/src/components/List/List.scss
@@ -7,8 +7,11 @@
 
 
 .ms-List {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   list-style-type: none;
 }
 
@@ -16,16 +19,16 @@
 //== Modifier: List rendered as a grid
 //
 .ms-List.ms-List--grid {
-	@media (min-width: $ms-screen-md-min) {
-		.ms-ListItem {
-			@include ms-u-sm4;
-			float: left;
-			border-width: 0 1px 1px;
-		}
+  @media (min-width: $ms-screen-md-min) {
+    .ms-ListItem {
+      @include ms-u-sm4;
+      float: left;
+      border-width: 0 1px 1px;
+    }
 
-		// Remove the border from the last column.
-		.ms-ListItem:nth-child(3n) {
-			border-width: 0 0 1px;
-		}
-	}
+    // Remove the border from the last column.
+    .ms-ListItem:nth-child(3n) {
+      border-width: 0 0 1px;
+    }
+  }
 }

--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -7,9 +7,12 @@
 
 
 .ms-ListItem {
-  @include ms-font-m;
   @include ms-u-normalize;
   @include ms-u-clearfix;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   padding: 9px 28px 3px;
   position: relative;
   display: block;
@@ -24,7 +27,7 @@
 
 .ms-ListItem-primaryText {
   color: $ms-color-neutralDark;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-xl;
   padding-right: 80px; // Prevent overlap with up to three actions.
   position: relative;
@@ -33,7 +36,7 @@
 
 .ms-ListItem-secondaryText {
   color: $ms-color-neutralPrimary;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-m;
   line-height: 25px;
   position: relative;
@@ -43,7 +46,7 @@
 
 .ms-ListItem-tertiaryText {
   color: $ms-color-neutralSecondaryAlt;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-m;
   position: relative;
   top: -9px;
@@ -53,7 +56,7 @@
 
 .ms-ListItem-metaText {
   color: $ms-color-neutralPrimary;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-xs;
   position: absolute;
   right: 30px;
@@ -112,7 +115,7 @@
   .ms-ListItem-secondaryText,
   .ms-ListItem-metaText {
     color: $ms-color-themePrimary;
-    font-family: $ms-font-family-semibold;
+    font-weight: $ms-font-weight-semibold;
   }
 }
 
@@ -225,7 +228,7 @@
   .ms-ListItem-secondaryText {
     @include noWrap;
     color: $ms-color-neutralSecondary;
-    font-family: $ms-font-family-regular;
+    font-weight: $ms-font-weight-regular;
     font-size: $ms-font-size-xs;
     padding-top: 6px;
   }

--- a/src/components/MessageBanner/MessageBanner.scss
+++ b/src/components/MessageBanner/MessageBanner.scss
@@ -9,7 +9,10 @@ $MessageBanner-height: 52px;
 $MessageBanner-iconSize: 40px;
 
 .ms-MessageBanner {
-  @include ms-font-s;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-s;
+  font-weight: $ms-font-weight-regular;
   position: relative;
   border-bottom: 1px solid $ms-color-neutralSecondaryAlt;
   background-color: $ms-color-themeLighterAlt;

--- a/src/components/OrgChart/OrgChart.scss
+++ b/src/components/OrgChart/OrgChart.scss
@@ -7,8 +7,11 @@
 
 
 .ms-OrgChart {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
 }
 
 .ms-OrgChart-groupTitle {

--- a/src/components/Overlay/Overlay.scss
+++ b/src/components/Overlay/Overlay.scss
@@ -10,10 +10,11 @@
   background-color: $ms-color-whiteTranslucent40;
   position: absolute;
   bottom: 0;
-  left:   0;
-  right:  0;
-  top:    0;
+  left: 0;
+  right: 0;
+  top: 0;
   z-index: $ms-zIndex-back;
+  font-family: $ms-font-family-base;
 }
 
 

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -34,6 +34,7 @@ $CommandButtonBlue: #2488D8;
   bottom: 0;
   right: 0;
   z-index: $ms-zIndex-front;
+  font-family: $ms-font-family-base;
 
   // Animations -- Default (anchored right)
   &.animate-in {
@@ -143,7 +144,7 @@ $CommandButtonBlue: #2488D8;
 
 // Header text at the top of the panel.
 .ms-Panel-headerText {
-  font-family: $ms-font-family-light;
+  font-weight: $ms-font-weight-light;
   font-size: $ms-font-size-xl;
   color: $ms-color-neutralPrimary;
   margin: 10px 0;

--- a/src/components/PanelHost/PanelHost.scss
+++ b/src/components/PanelHost/PanelHost.scss
@@ -2,106 +2,95 @@ $Panel-width-lightDismiss: 272px;
 
 // The panel covers the entire screen.
 .ms-PanelHost {
-	bottom: 0;
-	left: 0;
-	position: absolute;
-	right: 0;
-	top: 0;
-	pointer-events: none;
-	z-index: $ms-zIndex-front;
-	font-family: $ms-font-family-base;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  pointer-events: none;
+  z-index: $ms-zIndex-front;
+  font-family: $ms-font-family-base;
 }
-
-// .ms-PanelHost-inner {
-//		right: 0;
-//		top: 0;
-//		bottom: 0;
-//		width: auto;
-//		position: absolute;
-//		background-color: $ms-color-white;
-//		height: 100%;
-// }
-
 
 //== State: When the panel is open.
 //
 .ms-Panel.is-open {
-	display: block;
-	opacity: 1;
-	pointer-events: auto;
+  display: block;
+  opacity: 1;
+  pointer-events: auto;
 
-	.ms-Overlay {
-		display: block;
-		pointer-events: auto;
+  .ms-Overlay {
+    display: block;
+    pointer-events: auto;
 
-		@media screen and (-ms-high-contrast: active) {
-			opacity: 0;
-		}
-	}
+    @media screen and (-ms-high-contrast: active) {
+      opacity: 0;
+    }
+  }
 
-	&.ms-Panel-animateIn {
-		 @include ms-u-fadeIn100;
-	}
+  &.ms-Panel-animateIn {
+     @include ms-u-fadeIn100;
+  }
 
-	&.ms-Panel-animateOut {
-		@include ms-u-fadeOut100;
+  &.ms-Panel-animateOut {
+    @include ms-u-fadeOut100;
 
-		.ms-Overlay {
-			display: none;
-		}
-	}
+    .ms-Overlay {
+      display: none;
+    }
+  }
 
-	// Medium screens and up
-	@media (min-width: $ms-screen-md-min) {
-		// Animations -- Default (anchored right)
-		&.ms-Panel-animateIn {
-			@include ms-u-slideLeftIn40;
+  // Medium screens and up
+  @media (min-width: $ms-screen-md-min) {
+    // Animations -- Default (anchored right)
+    &.ms-Panel-animateIn {
+      @include ms-u-slideLeftIn40;
 
-			.ms-Overlay {
-				@include ms-u-fadeIn200;
-			}
-		}
+      .ms-Overlay {
+        @include ms-u-fadeIn200;
+      }
+    }
 
-		&.ms-Panel-animateOut {
-			@include ms-u-slideRightOut40;
+    &.ms-Panel-animateOut {
+      @include ms-u-slideRightOut40;
 
-			.ms-Overlay {
-				@include ms-u-fadeOut200;
-			}
-		}
+      .ms-Overlay {
+        @include ms-u-fadeOut200;
+      }
+    }
 
-		// Animations - Left panel (anchored left)
-		&.ms-Panel--left.ms-Panel-animateIn {
-			@include ms-u-slideRightIn40;
+    // Animations - Left panel (anchored left)
+    &.ms-Panel--left.ms-Panel-animateIn {
+      @include ms-u-slideRightIn40;
 
-			.ms-Overlay {
-				@include ms-u-fadeIn200;
-			}
-		}
+      .ms-Overlay {
+        @include ms-u-fadeIn200;
+      }
+    }
 
-		&.ms-Panel--left.ms-Panel-animateOut {
-			@include ms-u-slideLeftOut40;
+    &.ms-Panel--left.ms-Panel-animateOut {
+      @include ms-u-slideLeftOut40;
 
-			.ms-Overlay {
-				@include ms-u-fadeOut200;
-			}
-		}
+      .ms-Overlay {
+        @include ms-u-fadeOut200;
+      }
+    }
 
-		// Animate overlay to full opacity, activate pointer events
-		.ms-Overlay {
-			cursor: pointer;
-			opacity: 1;
-			pointer-events: auto;
-		}
+    // Animate overlay to full opacity, activate pointer events
+    .ms-Overlay {
+      cursor: pointer;
+      opacity: 1;
+      pointer-events: auto;
+    }
 
-		&.ms-Panel-animateIn,
-		&.ms-Panel--left.ms-Panel-animateIn {
-			.ms-Overlay {
-				@media screen and (-ms-high-contrast: active) {
-					opacity: 0;
-					animation-name: none;
-				}
-			}
-		}
-	}
+    &.ms-Panel-animateIn,
+    &.ms-Panel--left.ms-Panel-animateIn {
+      .ms-Overlay {
+        @media screen and (-ms-high-contrast: active) {
+          opacity: 0;
+          animation-name: none;
+        }
+      }
+    }
+  }
 }

--- a/src/components/PanelHost/PanelHost.scss
+++ b/src/components/PanelHost/PanelHost.scss
@@ -2,105 +2,106 @@ $Panel-width-lightDismiss: 272px;
 
 // The panel covers the entire screen.
 .ms-PanelHost {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  pointer-events: none;
-  z-index: $ms-zIndex-front;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
+	pointer-events: none;
+	z-index: $ms-zIndex-front;
+	font-family: $ms-font-family-base;
 }
 
 // .ms-PanelHost-inner {
-//    right: 0;
-//    top: 0;
-//    bottom: 0;
-//    width: auto;
-//    position: absolute;
-//    background-color: $ms-color-white;
-//    height: 100%;
+//		right: 0;
+//		top: 0;
+//		bottom: 0;
+//		width: auto;
+//		position: absolute;
+//		background-color: $ms-color-white;
+//		height: 100%;
 // }
 
 
 //== State: When the panel is open.
 //
 .ms-Panel.is-open {
-  display: block;
-  opacity: 1;
-  pointer-events: auto;
+	display: block;
+	opacity: 1;
+	pointer-events: auto;
 
-  .ms-Overlay {
-    display: block;
-    pointer-events: auto;
+	.ms-Overlay {
+		display: block;
+		pointer-events: auto;
 
-    @media screen and (-ms-high-contrast: active) {
-      opacity: 0;
-    }
-  }
+		@media screen and (-ms-high-contrast: active) {
+			opacity: 0;
+		}
+	}
 
-  &.ms-Panel-animateIn {
-     @include ms-u-fadeIn100;
-  }
+	&.ms-Panel-animateIn {
+		 @include ms-u-fadeIn100;
+	}
 
-  &.ms-Panel-animateOut {
-    @include ms-u-fadeOut100;
+	&.ms-Panel-animateOut {
+		@include ms-u-fadeOut100;
 
-    .ms-Overlay {
-      display: none;
-    }
-  }
+		.ms-Overlay {
+			display: none;
+		}
+	}
 
-  // Medium screens and up
-  @media (min-width: $ms-screen-md-min) {
-    // Animations -- Default (anchored right)
-    &.ms-Panel-animateIn {
-      @include ms-u-slideLeftIn40;
+	// Medium screens and up
+	@media (min-width: $ms-screen-md-min) {
+		// Animations -- Default (anchored right)
+		&.ms-Panel-animateIn {
+			@include ms-u-slideLeftIn40;
 
-      .ms-Overlay {
-        @include ms-u-fadeIn200;
-      }
-    }
+			.ms-Overlay {
+				@include ms-u-fadeIn200;
+			}
+		}
 
-    &.ms-Panel-animateOut {
-      @include ms-u-slideRightOut40;
+		&.ms-Panel-animateOut {
+			@include ms-u-slideRightOut40;
 
-      .ms-Overlay {
-        @include ms-u-fadeOut200;
-      }
-    }
+			.ms-Overlay {
+				@include ms-u-fadeOut200;
+			}
+		}
 
-    // Animations - Left panel (anchored left)
-    &.ms-Panel--left.ms-Panel-animateIn {
-      @include ms-u-slideRightIn40;
+		// Animations - Left panel (anchored left)
+		&.ms-Panel--left.ms-Panel-animateIn {
+			@include ms-u-slideRightIn40;
 
-      .ms-Overlay {
-        @include ms-u-fadeIn200;
-      }
-    }
+			.ms-Overlay {
+				@include ms-u-fadeIn200;
+			}
+		}
 
-    &.ms-Panel--left.ms-Panel-animateOut {
-      @include ms-u-slideLeftOut40;
+		&.ms-Panel--left.ms-Panel-animateOut {
+			@include ms-u-slideLeftOut40;
 
-      .ms-Overlay {
-        @include ms-u-fadeOut200;
-      }
-    }
+			.ms-Overlay {
+				@include ms-u-fadeOut200;
+			}
+		}
 
-    // Animate overlay to full opacity, activate pointer events
-    .ms-Overlay {
-      cursor: pointer;
-      opacity: 1;
-      pointer-events: auto;
-    }
+		// Animate overlay to full opacity, activate pointer events
+		.ms-Overlay {
+			cursor: pointer;
+			opacity: 1;
+			pointer-events: auto;
+		}
 
-    &.ms-Panel-animateIn,
-    &.ms-Panel--left.ms-Panel-animateIn {
-      .ms-Overlay {
-        @media screen and (-ms-high-contrast: active) {
-          opacity: 0;
-          animation-name: none;
-        }
-      }
-    }
-  }
+		&.ms-Panel-animateIn,
+		&.ms-Panel--left.ms-Panel-animateIn {
+			.ms-Overlay {
+				@media screen and (-ms-high-contrast: active) {
+					opacity: 0;
+					animation-name: none;
+				}
+			}
+		}
+	}
 }

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -9,8 +9,10 @@ $personaItemHeight: 42px;
 $ms-Persona-leftPadding: 16px;
 
 .ms-PeoplePicker {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
   background-color: $ms-color-white;
   margin-bottom: 10px;
 }
@@ -99,7 +101,7 @@ $ms-Persona-leftPadding: 16px;
 // Title for a group of results (optional)
 .ms-PeoplePicker-resultGroupTitle {
   color: $ms-color-themePrimary;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-s;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -320,12 +322,12 @@ $ms-Persona-leftPadding: 16px;
 // Primary text
 .ms-PeoplePicker-searchMorePrimary {
   padding-top: 2px;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
 }
 
 // Secondary text
 .ms-PeoplePicker-searchMoreSecondary {
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-xs;
   color: $ms-color-neutralSecondary;
 }
@@ -347,7 +349,7 @@ $ms-Persona-leftPadding: 16px;
   // Primary text
   .ms-PeoplePicker-searchMorePrimary {
     color: $ms-color-neutralSecondary;
-    font-family: $ms-font-family-semilight;
+    font-weight: $ms-font-weight-semilight;
     font-size: $ms-font-size-xs;
     line-height: 20px;
     position: relative;
@@ -577,7 +579,7 @@ $ms-Persona-leftPadding: 16px;
 .ms-PeoplePicker-peopleListHeader {
   color: $ms-color-themePrimary;
   font-size: $ms-font-size-s;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
   height: 50px;
   line-height: 50px;
 }

--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -59,8 +59,11 @@ $ms-Persona-presenceSizeXl: 28px;
 
 
 .ms-Persona {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   line-height: 1;
   position: relative;
   width: 100%;
@@ -111,7 +114,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona-initials {
   color: $ms-color-white;
   font-size: $ms-font-size-l;
-  font-family: $ms-font-family-light;
+  font-weight: $ms-font-weight-light;
   line-height: $ms-Persona-sizeMd;
 
   &.ms-Persona-initials--lightBlue {
@@ -230,7 +233,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
 .ms-Persona-primaryText {
   color: $ms-color-neutralPrimary;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-l;
   margin-top: -3px;
   line-height: 1.4;
@@ -240,7 +243,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .ms-Persona-tertiaryText,
 .ms-Persona-optionalText {
   color: $ms-color-neutralSecondary;
-  font-family: $ms-font-family-regular;
+  font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-s;
   white-space: nowrap;
   line-height: 1.3;
@@ -559,7 +562,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .ms-Persona-primaryText {
     font-size: $ms-font-size-xl;
-    font-family: $ms-font-family-semilight;
+    font-weight: $ms-font-weight-semilight;
     margin-top: 0;
   }
 

--- a/src/components/PersonaCard/PersonaCard.scss
+++ b/src/components/PersonaCard/PersonaCard.scss
@@ -10,8 +10,11 @@
 //
 // The persona card docks to the bottom of the viewport.
 .ms-PersonaCard {
-  @include ms-font-m;
   @include ms-u-slideUpIn10;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   bottom: 0;
   left: 0;
   position: fixed;

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -7,8 +7,11 @@
 
 
 .ms-Pivot {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   height: 30px;
   list-style-type: none;
   overflow-x: hidden;
@@ -18,7 +21,7 @@
 .ms-Pivot-link {
   color: $ms-color-neutralPrimary;
   display: inline-block;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-m-plus;
   line-height: 27px;
   margin-right: 15px;
@@ -36,7 +39,7 @@
   //== State: Selected
   &.is-selected {
     color: $ms-color-themePrimary;
-    font-family: $ms-font-family-semibold;
+    font-weight: $ms-font-weight-semibold;
   }
 }
 
@@ -73,7 +76,7 @@
     font-size: $ms-font-size-l;
 
     &.is-selected {
-      font-family: $ms-font-family-semilight;
+      font-weight: $ms-font-weight-semilight;
     }
   }
 
@@ -111,7 +114,7 @@
     &.is-selected {
       background-color: $ms-color-themePrimary;
       color: $ms-color-white;
-      font-family: $ms-font-family-semilight;
+      font-weight: $ms-font-weight-semilight;
     }
   }
 
@@ -148,7 +151,7 @@
   .ms-Pivot.ms-Pivot--tabs {
     .ms-Pivot-link {
       &.is-selected {
-        font-family: $ms-font-family-semibold;
+        font-weight: $ms-font-weight-semibold;
       }
     }
   }

--- a/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -11,7 +11,10 @@ $ProgressIndicatorButtonsWidth: 218px;
 $ProgressIndicatorTextHeight: 18px;
 
 .ms-ProgressIndicator-itemName {
-  @include ms-font-m;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -20,9 +23,10 @@ $ProgressIndicatorTextHeight: 18px;
 }
 
 .ms-ProgressIndicator-itemDescription {
-  @include ms-font-m;
+  font-family: $ms-font-family-base;
+  font-weight: $ms-font-weight-regular;
   color: $ms-color-neutralSecondaryAlt;
-  font-size: 11px;
+  font-size: $ms-font-size-xs;
   line-height: $ProgressIndicatorTextHeight;
 }
 

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -7,8 +7,11 @@
 
 
 .ms-SearchBox {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   position: relative;
   display: inline-block;
   overflow: hidden;
@@ -76,7 +79,7 @@
   border: 1px solid $ms-color-themeTertiary;
   outline: transparent 1px solid;
   border-radius: 0;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-m;
   color: $ms-color-black;
   height: 32px;

--- a/src/components/Spinner/Spinner.scss
+++ b/src/components/Spinner/Spinner.scss
@@ -9,6 +9,7 @@
 .ms-Spinner {
   position: relative;
   height: 20px;
+  font-family: $ms-font-family-base;
 
   &.ms-Spinner--large {
     height: 28px;
@@ -37,7 +38,9 @@
 
 .ms-Spinner-label {
   position: relative;
-  @include ms-font-s;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-s;
+  font-weight: $ms-font-weight-regular;
   color: $ms-color-themePrimary;
   left: 28px;
   top: 2px;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -6,130 +6,131 @@
 // Data table styles
 
 .ms-Table {
-  display: table;
-  width: 100%;
-  border-collapse: collapse;
+	display: table;
+	width: 100%;
+	border-collapse: collapse;
+	font-family: $ms-font-family-base;
 }
 
 // makes the table cells not expand with the content, keeping the table cells at a fixed size
 .ms-Table--fixed {
-  table-layout: fixed;
+	table-layout: fixed;
 }
 
 .ms-Table tr,
 .ms-Table-row {
-  display: table-row;
-  line-height: 30px;
-  font-family: $ms-font-family-semilight;
-  font-size: $ms-font-size-s;
-  color: $ms-color-neutralPrimary;
+	display: table-row;
+	line-height: 30px;
+	font-weight: $ms-font-weight-semilight;
+	font-size: $ms-font-size-s;
+	color: $ms-color-neutralPrimary;
 
-  &:hover {
-    background-color: $ms-color-neutralLighter;
-    cursor: pointer;
-    outline: 1px solid transparent;
-  }
+	&:hover {
+		background-color: $ms-color-neutralLighter;
+		cursor: pointer;
+		outline: 1px solid transparent;
+	}
 
-  // Rows can be selected.
-  &.is-selected {
-    background-color: $ms-color-themeLight;
+	// Rows can be selected.
+	&.is-selected {
+		background-color: $ms-color-themeLight;
 
-    // A checkmark in a selected row.
-    .ms-Table-rowCheck {
-      background-color: $ms-color-themePrimary;
+		// A checkmark in a selected row.
+		.ms-Table-rowCheck {
+			background-color: $ms-color-themePrimary;
 
-      // Hide the checkbox.
-      &:before {
-        display: none;
-      }
+			// Hide the checkbox.
+			&:before {
+				display: none;
+			}
 
-      // But show the mark.
-      &:after {
-        @include ms-Icon;
-        content: '\e041';
-        color: $ms-color-white;
-        font-size: 12px;
-        position: absolute;
-        left: 4px;
-        top: 9px;
-      }
-    }
-  }
+			// But show the mark.
+			&:after {
+				@include ms-Icon;
+				content: '\e041';
+				color: $ms-color-white;
+				font-size: 12px;
+				position: absolute;
+				left: 4px;
+				top: 9px;
+			}
+		}
+	}
 }
 
 .ms-Table th,
 .ms-Table td,
 .ms-Table-cell {
-  display: table-cell;
-  padding: 0 10px;
+	display: table-cell;
+	padding: 0 10px;
 }
 
 // Style the first row as a header.
 .ms-Table thead th,
 .ms-Table-head {
-  font-family: $ms-font-family-semilight;
-  font-size: $ms-font-size-xs;
-  color: $ms-color-neutralSecondary;
+	font-weight: $ms-font-weight-semilight;
+	font-size: $ms-font-size-xs;
+	color: $ms-color-neutralSecondary;
 }
 
 .ms-Table thead,
 .ms-Table-head {
-  td,
-  th,
-  .ms-Table-cell,
-  .ms-Table-rowCheck {
-    font-weight: normal;
-    text-align: left;
-    border-bottom: 1px solid $ms-color-neutralLight;
-  }
+	td,
+	th,
+	.ms-Table-cell,
+	.ms-Table-rowCheck {
+		font-weight: normal;
+		text-align: left;
+		border-bottom: 1px solid $ms-color-neutralLight;
+	}
 
-  .ms-Table-rowCheck {
-    &::after {
-      @include ms-Icon;
-      content: '\e041';
-      color: $ms-color-neutralTertiary;
-      font-size: 12px;
-      position: absolute;
-      left: 4px;
-      top: 9px;
-    }
-  }
+	.ms-Table-rowCheck {
+		&::after {
+			@include ms-Icon;
+			content: '\e041';
+			color: $ms-color-neutralTertiary;
+			font-size: 12px;
+			position: absolute;
+			left: 4px;
+			top: 9px;
+		}
+	}
 }
 
 // On selectable tables, each row has a checkbox.
 .ms-Table-rowCheck {
-  display: table-cell;
-  width: 20px;
-  position: relative;
-  padding: 0;
+	display: table-cell;
+	width: 20px;
+	position: relative;
+	padding: 0;
 
-  // Empty checkbox.
-  &:before {
-    border: 1px solid $ms-color-neutralTertiary;
-    content: '';
-    display: block;
-    height: 14px;
-    left: 2px;
-    position: absolute;
-    top: 6px;
-    width: 14px;
-  }
+	// Empty checkbox.
+	&:before {
+		border: 1px solid $ms-color-neutralTertiary;
+		content: '';
+		display: block;
+		height: 14px;
+		left: 2px;
+		position: absolute;
+		top: 6px;
+		width: 14px;
+	}
 }
 
 // All high contrast styling rules
 @media screen and (-ms-high-contrast: active) {
-  .ms-Table-row {
-    // Rows can be selected.
-    &.is-selected {
-      // A checkmark in a selected row.
-      .ms-Table-rowCheck {
-        background: none;
+	.ms-Table-row {
+		// Rows can be selected.
+		&.is-selected {
+			// A checkmark in a selected row.
+			.ms-Table-rowCheck {
+				background: none;
 
-        // Show the checkbox.
-        &:before {
-          display: block;
-        }
-      }
-    }
-  }
+				// Show the checkbox.
+				&:before {
+					display: block;
+				}
+			}
+		}
+	}
 }

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -6,131 +6,131 @@
 // Data table styles
 
 .ms-Table {
-	display: table;
-	width: 100%;
-	border-collapse: collapse;
-	font-family: $ms-font-family-base;
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+  font-family: $ms-font-family-base;
 }
 
 // makes the table cells not expand with the content, keeping the table cells at a fixed size
 .ms-Table--fixed {
-	table-layout: fixed;
+  table-layout: fixed;
 }
 
 .ms-Table tr,
 .ms-Table-row {
-	display: table-row;
-	line-height: 30px;
-	font-weight: $ms-font-weight-semilight;
-	font-size: $ms-font-size-s;
-	color: $ms-color-neutralPrimary;
+  display: table-row;
+  line-height: 30px;
+  font-weight: $ms-font-weight-semilight;
+  font-size: $ms-font-size-s;
+  color: $ms-color-neutralPrimary;
 
-	&:hover {
-		background-color: $ms-color-neutralLighter;
-		cursor: pointer;
-		outline: 1px solid transparent;
-	}
+  &:hover {
+    background-color: $ms-color-neutralLighter;
+    cursor: pointer;
+    outline: 1px solid transparent;
+  }
 
-	// Rows can be selected.
-	&.is-selected {
-		background-color: $ms-color-themeLight;
+  // Rows can be selected.
+  &.is-selected {
+    background-color: $ms-color-themeLight;
 
-		// A checkmark in a selected row.
-		.ms-Table-rowCheck {
-			background-color: $ms-color-themePrimary;
+    // A checkmark in a selected row.
+    .ms-Table-rowCheck {
+      background-color: $ms-color-themePrimary;
 
-			// Hide the checkbox.
-			&:before {
-				display: none;
-			}
+      // Hide the checkbox.
+      &:before {
+        display: none;
+      }
 
-			// But show the mark.
-			&:after {
-				@include ms-Icon;
-				content: '\e041';
-				color: $ms-color-white;
-				font-size: 12px;
-				position: absolute;
-				left: 4px;
-				top: 9px;
-			}
-		}
-	}
+      // But show the mark.
+      &:after {
+        @include ms-Icon;
+        content: '\e041';
+        color: $ms-color-white;
+        font-size: 12px;
+        position: absolute;
+        left: 4px;
+        top: 9px;
+      }
+    }
+  }
 }
 
 .ms-Table th,
 .ms-Table td,
 .ms-Table-cell {
-	display: table-cell;
-	padding: 0 10px;
+  display: table-cell;
+  padding: 0 10px;
 }
 
 // Style the first row as a header.
 .ms-Table thead th,
 .ms-Table-head {
-	font-weight: $ms-font-weight-semilight;
-	font-size: $ms-font-size-xs;
-	color: $ms-color-neutralSecondary;
+  font-weight: $ms-font-weight-semilight;
+  font-size: $ms-font-size-xs;
+  color: $ms-color-neutralSecondary;
 }
 
 .ms-Table thead,
 .ms-Table-head {
-	td,
-	th,
-	.ms-Table-cell,
-	.ms-Table-rowCheck {
-		font-weight: normal;
-		text-align: left;
-		border-bottom: 1px solid $ms-color-neutralLight;
-	}
+  td,
+  th,
+  .ms-Table-cell,
+  .ms-Table-rowCheck {
+    font-weight: normal;
+    text-align: left;
+    border-bottom: 1px solid $ms-color-neutralLight;
+  }
 
-	.ms-Table-rowCheck {
-		&::after {
-			@include ms-Icon;
-			content: '\e041';
-			color: $ms-color-neutralTertiary;
-			font-size: 12px;
-			position: absolute;
-			left: 4px;
-			top: 9px;
-		}
-	}
+  .ms-Table-rowCheck {
+    &::after {
+      @include ms-Icon;
+      content: '\e041';
+      color: $ms-color-neutralTertiary;
+      font-size: 12px;
+      position: absolute;
+      left: 4px;
+      top: 9px;
+    }
+  }
 }
 
 // On selectable tables, each row has a checkbox.
 .ms-Table-rowCheck {
-	display: table-cell;
-	width: 20px;
-	position: relative;
-	padding: 0;
+  display: table-cell;
+  width: 20px;
+  position: relative;
+  padding: 0;
 
-	// Empty checkbox.
-	&:before {
-		border: 1px solid $ms-color-neutralTertiary;
-		content: '';
-		display: block;
-		height: 14px;
-		left: 2px;
-		position: absolute;
-		top: 6px;
-		width: 14px;
-	}
+  // Empty checkbox.
+  &:before {
+    border: 1px solid $ms-color-neutralTertiary;
+    content: '';
+    display: block;
+    height: 14px;
+    left: 2px;
+    position: absolute;
+    top: 6px;
+    width: 14px;
+  }
 }
 
 // All high contrast styling rules
 @media screen and (-ms-high-contrast: active) {
-	.ms-Table-row {
-		// Rows can be selected.
-		&.is-selected {
-			// A checkmark in a selected row.
-			.ms-Table-rowCheck {
-				background: none;
+  .ms-Table-row {
+    // Rows can be selected.
+    &.is-selected {
+      // A checkmark in a selected row.
+      .ms-Table-rowCheck {
+        background: none;
 
-				// Show the checkbox.
-				&:before {
-					display: block;
-				}
-			}
-		}
-	}
+        // Show the checkbox.
+        &:before {
+          display: block;
+        }
+      }
+    }
+  }
 }

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -8,8 +8,11 @@
 // Single line (input) and multiline (textarea) form field styles
 
 .ms-TextField {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   margin-bottom: 8px;
 }
 
@@ -47,7 +50,7 @@
   @include ms-u-normalize;
   border: 1px solid $ms-color-neutralTertiaryAlt;
   border-radius: 0;
-  font-family: $ms-font-family-semilight;
+  font-weight: $ms-font-weight-semilight;
   font-size: $ms-font-size-s;
   color: $ms-color-neutralPrimary;
   height: 32px;
@@ -93,7 +96,7 @@
 
   .ms-Label {
     position: absolute;
-    font-family: $ms-font-family-semilight;
+    font-weight: $ms-font-weight-semilight;
     font-size: $ms-font-size-s;
     color: $ms-color-neutralSecondary;
     padding: 7px 0 7px 10px;
@@ -192,7 +195,10 @@
 //
 .ms-TextField.ms-TextField--multiline {
   .ms-TextField-field {
-    @include ms-font-s;
+    color: $ms-color-neutralPrimary;
+    font-family: $ms-font-family-base;
+    font-size: $ms-font-size-s;
+    font-weight: $ms-font-weight-regular;
     line-height: 17px;
     min-height: 60px;
     min-width: 260px;

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -55,8 +55,11 @@
 
 // Toggle
 .ms-Toggle {
-  @include ms-font-m;
   @include ms-u-normalize;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
   position: relative;
   display: block;
   margin-bottom: 26px;

--- a/src/sass/_Fabric.Typography.Language.Overrides.scss
+++ b/src/sass/_Fabric.Typography.Language.Overrides.scss
@@ -8,8 +8,8 @@
 
 // A mixin that overrides all of the font classes for languages that
 // use system fonts. A single font-family is used for all weights.
-@mixin language-override-system-fonts($ms-lang-code, $ms-font-family-base) {
-  *[lang="#{$ms-lang-code}"] {
+@mixin language-override-system-fonts($lang-code, $font-family) {
+  *[lang="#{$lang-code}"] {
     .ms-font-mi,
     .ms-font-xs,
     .ms-font-s,
@@ -28,7 +28,7 @@
     .ms-fontWeight-regular-hover:hover,
     .ms-fontWeight-semibold,
     .ms-fontWeight-semibold-hover:hover {
-      font-family: $ms-font-family-base;
+      font-family: $font-family;
     }
   }
 }

--- a/src/sass/_Fabric.Typography.Variables.scss
+++ b/src/sass/_Fabric.Typography.Variables.scss
@@ -8,11 +8,6 @@
 $ms-font-system-base: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
 $ms-font-family-base:  'Segoe UI WestEuropean', $ms-font-system-base;
 
-$ms-font-family-light:     'Segoe UI Light', $ms-font-system-base;
-$ms-font-family-regular:   $ms-font-system-base;
-$ms-font-family-semilight: 'Segoe UI Semilight', $ms-font-system-base;
-$ms-font-family-semibold:  'Segoe UI Semibold', $ms-font-system-base;
-
 $ms-font-weight-light:     100;
 $ms-font-weight-regular:   400;
 $ms-font-weight-semilight: 300;


### PR DESCRIPTION
Now that we're using `font-weight` to control the font weight, rather than `font-family`, the Segoe web font was not loading correctly in any of the components.

This PR adds the base font family to every component's root element (e.g. `.ms-Button`) so that all child elements inherit the correct font. It then sets the `font-weight` wherever `font-family` was being used previously.

I've also replaced all of the `@include` calls which were setting `font-family`, `font-weight`, `font-size`, and `color` all at once. This can be convenient but it often leads to output with duplicate properties such as:

```
.ms-Component {
  font-family: ...
  font-weight: 100;
  font-size: 16px;
  color: #666666;
  font-weight: 300;
  font-size: 14px;
}
```

It also converts all tabs to spaces.