### PR TITLE
Fix 201510, 201562: 3.0.0: Link: Empty title and tabindex, Link not selectable

### DIFF
--- a/src/components/Link/Link.hbs
+++ b/src/components/Link/Link.hbs
@@ -2,6 +2,6 @@
 
 <a class="ms-Link {{props.customClasses}} {{#if props.modifierClass}} ms-Link--{{props.modifierClass}} {{/if}}" 
   {{#if props.href}} href="{{props.href}}" {{/if}} 
-  title="{{props.title}}" 
-  tabindex="{{props.tabIndex}}">{{props.label}}</a>
+  {{#if props.title}} title="{{props.title}}" {{/if}} 
+  {{#if props.tabIndex}} tabindex="{{props.tabIndex}}" {{/if}}>{{props.label}}</a>
 

--- a/src/documentation/pages/Link/examples/LinkModels.js
+++ b/src/documentation/pages/Link/examples/LinkModels.js
@@ -1,8 +1,8 @@
 var LinkModels = {  
   "basic": {
     "label": "Example Link",
-    "href": "",
-    "title": "",
+    "href": "#",
+    "title": "More info about Example Link",
     "tabIndex": ""
   }
 }


### PR DESCRIPTION
Update link with href and add conditionals for title and tabIndex attributes.