### PR TITLE
Add keyboard accessibility to OrgChart

### DIFF
--- a/src/components/OrgChart/OrgChart.hbs
+++ b/src/components/OrgChart/OrgChart.hbs
@@ -7,7 +7,7 @@
       <ul class="ms-OrgChart-list">
         {{#each personas}}
           <li class="ms-OrgChart-listItem">
-            <button class="ms-OrgChart-listItemBtn">
+            <button class="ms-OrgChart-listItemBtn" tabindex="1">
               {{renderPartial component props}}
             </button>
           </li>

--- a/src/components/OrgChart/OrgChart.scss
+++ b/src/components/OrgChart/OrgChart.scss
@@ -42,5 +42,4 @@
   text-align: left;
   margin: 0;
   padding: 0;
-  outline: transparent;
 }

--- a/src/components/Persona/Persona.hbs
+++ b/src/components/Persona/Persona.hbs
@@ -5,7 +5,7 @@
     {{#each props.modifiers}}
       ms-Persona--{{name}}
      {{/each}}
-  {{/if}}" tabindex="1">
+  {{/if}}">
   <div class="ms-Persona-imageArea">
     {{#if props.initials}}
       <div class="ms-Persona-initials ms-Persona-initials--{{props.initialsColor}}">{{props.initials}}</div>


### PR DESCRIPTION
Removes tabindex from Persona (only some variants are actionable) and adds tabindex to the OrgChart.