### PR TITLE
MessageBanner demonstration and focus states

### DIFF
--- a/src/components/MessageBanner/MessageBanner.scss
+++ b/src/components/MessageBanner/MessageBanner.scss
@@ -43,10 +43,6 @@ $MessageBanner-iconSize: 40px;
   cursor: pointer;
   border: 0;
   background-color: transparent;
-
-  &:focus {
-    outline: 1px solid transparent;
-  }
 }
 
 .ms-MessageBanner-close {

--- a/src/documentation/pages/MessageBanner/examples/MessageBannerExample.hbs
+++ b/src/documentation/pages/MessageBanner/examples/MessageBannerExample.hbs
@@ -1,6 +1,15 @@
-{{> MessageBanner props=props}}
+<div class="docs-MessageBannerExample">
+  {{> MessageBanner props=props }}
+  <button class="ms-Button docs-MessageBannerExample-button">Show the banner</button>
+</div>
 
 <script type="text/javascript">
-  var MessageBannerHTML = document.querySelector('.ms-MessageBanner');
-  var MessageBanner = new fabric['MessageBanner'](MessageBannerHTML);
+  var MessageBannerExample = document.querySelector('.docs-MessageBannerExample');
+  var MessageBanner = new fabric['MessageBanner'](MessageBannerExample.querySelector('.ms-MessageBanner'));
+  var MessageBannerButton = MessageBannerExample.querySelector('.docs-MessageBannerExample-button');
+  
+  // When clicking the button, open the MessageBanner
+  MessageBannerButton.onclick = function() {
+    MessageBanner.showBanner();
+  };
 </script>


### PR DESCRIPTION
Added a simple button to open the MessageBanner, and removed our `outline: none` override that was preventing the close button for showing a focus state. We'll want to style this better in the future but at least it's accessible for now.

![image](https://cloud.githubusercontent.com/assets/1382445/15435115/4fbcf574-1e6f-11e6-9c76-8d8ca824eee0.png)
