### PR TITLE
Import MessageBar into the main components' Sass file

### DIFF
--- a/src/sass/Fabric.Components.scss
+++ b/src/sass/Fabric.Components.scss
@@ -15,6 +15,7 @@
 @import '../components/List/List';
 @import '../components/ListItem/ListItem';
 @import '../components/MessageBanner/MessageBanner';
+@import '../components/MessageBar/MessageBar';
 @import '../components/NavBar/NavBar';
 @import '../components/OrgChart/OrgChart';
 @import '../components/Overlay/Overlay';


### PR DESCRIPTION
Fixes #596 

Will be included in a 2.6.1 patch release.