### PR TITLE
Remove the deprecated 'hero' link from Callout

### DIFF
--- a/src/components/Callout/Callout.scss
+++ b/src/components/Callout/Callout.scss
@@ -71,10 +71,6 @@ $ms-Callout-commandButtonHeight: 27px;
   width: 100%;
   white-space: nowrap;
 
-  .ms-Link.ms-Link--hero {
-    left: -8px; // Move link inline with body text
-  }
-
   .ms-CommandButton.ms-CommandButton--inline {
     height: $ms-Callout-commandButtonHeight;
     line-height: $ms-Callout-commandButtonHeight;

--- a/src/documentation/pages/Callout/Callout.md
+++ b/src/documentation/pages/Callout/Callout.md
@@ -59,7 +59,7 @@ This component has only the default state.
                     <p class="ms-Callout-subText">Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</p>
                 </div>
                 <div class="ms-Callout-actions">
-                    <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
+                    <a href="#" class="ms-Callout-link">Learn more</a>
                 </div>
             </div>    
         </div>

--- a/src/documentation/pages/Callout/examples/CalloutExampleModel.js
+++ b/src/documentation/pages/Callout/examples/CalloutExampleModel.js
@@ -11,8 +11,7 @@ var CalloutExampleModel = {
           "linkText": "Learn More",
           "customClassses": "ms-Callout-link",
           "tabIndex": 0,
-          "hasHref": false,
-          "modifierClass": "ms-Link--hero"
+          "hasHref": false
         }
       }
     ],


### PR DESCRIPTION
Fixes #460.

Final result:
![image](https://cloud.githubusercontent.com/assets/1382445/15801439/88d50230-2a49-11e6-9fcc-96a5ac53aee8.png)
