### PR TITLE
Hero button spacing

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -125,6 +125,7 @@
 //== Modifier: Hero button
 //
 .ms-Button.ms-Button--hero {
+  align-items: center;
   background-color: transparent;
   border: 0;
   display: flex;
@@ -139,10 +140,10 @@
     .ms-Icon {
       border-radius: 18px;
       border: 1px solid $ms-color-themePrimary;
+      font-size: $ms-font-size-s;
       height: 18px;
       line-height: 18px;
       width: 18px;
-      font-size: $ms-font-size-s;
     }
   }
 
@@ -150,7 +151,6 @@
     color: $ms-color-themePrimary;
     font-size: $ms-font-size-xl;
     font-weight: $ms-font-weight-light;
-    line-height: 19px;
     position: relative;
     text-decoration: none;
   }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -15,7 +15,6 @@
   background-color: $ms-color-neutralLighter;
   border: 1px solid $ms-color-neutralLighter;
   cursor: pointer;
-  display: inline-block;
   height: 32px;
   min-width: 80px;
   padding: 4px 20px 6px;
@@ -128,15 +127,13 @@
 .ms-Button.ms-Button--hero {
   background-color: transparent;
   border: 0;
-  vertical-align: top;
-  line-height: normal;
+  display: flex;
+  padding: 0;
 
   .ms-Button-icon {
     color: $ms-color-themePrimary;
-    display: inline-block;
-    font-size: $ms-font-size-s;
-    position: relative;
-    top: -8px;
+    display: block;
+    margin-right: 4px;
     text-align: center;
 
     .ms-Icon {
@@ -146,16 +143,15 @@
       line-height: 18px;
       width: 18px;
       font-size: $ms-font-size-s;
-      margin: 0;
     }
   }
 
   .ms-Button-label {
     color: $ms-color-themePrimary;
-    font-weight: $ms-font-weight-light;
     font-size: $ms-font-size-xl;
+    font-weight: $ms-font-weight-light;
+    line-height: 19px;
     position: relative;
-    top: -5px;
     text-decoration: none;
   }
 


### PR DESCRIPTION
Fixes #345.

Now that IE9 support is no longer a requirement, we can fix this pesky bug. The previous `display: inline-block` method of placing the icon next to the label was sensitive to spaces in the HTML. This now uses `display: flex` to position the elements. An added benefit is that we don't have to approximate vertical centering by using line height – we now have proper vertical centering that even looks correct in IE10.

Chrome
![image](https://cloud.githubusercontent.com/assets/1382445/15905877/6fa75a7c-2d6b-11e6-8ca3-2c394d3b9c6a.png)

IE10
![image](https://cloud.githubusercontent.com/assets/1382445/15906043/14d440aa-2d6c-11e6-9e7f-891410aaafec.png)

Thanks to @chrisahhh for the [original pull request](https://github.com/OfficeDev/Office-UI-Fabric/pull/434) and suggestions on how to fix this.