### PR TITLE
Use the disabled attribute for disabled TextFields

### DIFF
--- a/src/components/TextField/TextField.hbs
+++ b/src/components/TextField/TextField.hbs
@@ -1,8 +1,8 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
-<div class="ms-TextField {{#if props.modifier}} ms-TextField--{{props.modifier}}{{/if}}">
+<div class="ms-TextField {{#if props.modifier}} ms-TextField--{{props.modifier}}{{/if}} {{#if props.disabled}}is-disabled{{/if}}">
   {{#if props.label}}<label class="ms-Label">{{props.label}}</label>{{/if}}
-  {{#if props.textfield}}<input class="ms-TextField-field" type="text" value="{{props.value}}" placeholder="{{props.placeholder}}">{{/if}}
-  {{#if props.multiline}}<textarea class="ms-TextField-field"></textarea>{{/if}}
+  {{#if props.textfield}}<input class="ms-TextField-field" type="text" value="{{props.value}}" placeholder="{{props.placeholder}}" {{#if props.disabled}}disabled{{/if}}>{{/if}}
+  {{#if props.multiline}}<textarea class="ms-TextField-field" {{#if props.disabled}}disabled{{/if}}></textarea>{{/if}}
   {{#if props.description}}<span class="ms-TextField-description">{{props.description}}</span>{{/if}}
 </div>

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -78,6 +78,13 @@
     }
   }
 
+  &[disabled] {
+    background-color: $ms-color-neutralLighter;
+    border-color: $ms-color-neutralLighter;
+    pointer-events: none;
+    cursor: default;
+  }
+
   @include input-placeholder {
     color: $ms-color-neutralSecondary;
   }

--- a/src/documentation/pages/TextField/TextField.md
+++ b/src/documentation/pages/TextField/TextField.md
@@ -28,6 +28,13 @@ Allows for the input of text. Can be a single line or multiple lines. Typically 
 {{> TextField props=TextFieldTextFieldUnderlinedExampleModel}}
 --->
 
+## States
+
+### Disabled
+<!---
+{{> TextField props=TextFieldDisabledExampleModel}}
+--->
+
 ## Using this component
 1. Confirm that you have references to Fabric's CSS on your page:
     ```

--- a/src/documentation/pages/TextField/examples/TextFieldDisabledExampleModel.js
+++ b/src/documentation/pages/TextField/examples/TextFieldDisabledExampleModel.js
@@ -1,0 +1,7 @@
+var TextFieldDisabledExampleModel = {
+  "label": "Name",
+  "textfield": true,
+  "disabled": true
+}
+
+module.exports = TextFieldDisabledExampleModel;


### PR DESCRIPTION
Fixes #500 

This PR adds a disabled property to the TextField, which both adds the `is-disabled` state class (to style the label) and adds a `disabled` attribute to the field itself. This ensures that the field is actually disabled across all browsers and doesn't just appear so.

![image](https://cloud.githubusercontent.com/assets/1382445/15906627/836783e0-2d6e-11e6-80be-1125fba515db.png)
