### PR TITLE
Fix left panel modifier

### DIFF
--- a/src/components/Panel/Panel.hbs
+++ b/src/components/Panel/Panel.hbs
@@ -1,10 +1,5 @@
 <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 <div class="ms-Panel {{#if props.modifier}}{{#each props.modifier}} ms-Panel--{{name}}{{/each}}{{/if}}">
-    {{#if props.commandBarProps}}
-        <div class="ms-Panel-commands">
-            {{> CommandBar props=props.commandBarProps}}
-        </div>
-     {{/if}}
     <button class="ms-Panel-closeButton ms-PanelAction-close">
         <i class="ms-Panel-closeIcon ms-Icon ms-Icon--x"></i>
     </button>

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -5,28 +5,23 @@
 // --------------------------------------------------
 // Panel styles
 
-$Panel-width-lightDismiss: 272px;
+$ms-panel-width-sm: 272px;
+$ms-panel-width-md: 340px;
+$ms-panel-width-lg: 644px;
+$ms-panel-width-xl: 940px;
+$ms-panel-width-xxl: 1192px;
 
-$Panel-width-sm: 272px;
-$Panel-width-md: 340px;
-$Panel-width-lg: 644px;
-$Panel-width-xl: 940px;
-$Panel-width-xxl: 1192px;
+$ms-panel-margin-md: 48px;
+$ms-panel-margin-lg: 428px;
+$ms-panel-margin-xl: 176px;
 
-$Panel-margin-md: 48px;
-$Panel-margin-lg: 428px;
-$Panel-margin-xl: 176px;
-$CommandBarHeight: 40px;
-$CommandButtonLightBlue: #B5D8F4;
-$CommandButtonLighterBlue: #D7EAF9;
-$CommandButtonDarkBlue: #07288B;
-$CommandButtonBlue: #2488D8;
+$ms-panel-command-bar-height: 40px;
 
 // The panel itself, where the content goes.
 .ms-Panel {
   background-color: $ms-color-white;
   width: 100%;
-  max-width: $Panel-width-sm;
+  max-width: $ms-anel-width-sm;
   @include drop-shadow(-30px, 0, 30px, -30px, .2);
   position: absolute;
   top: 0;
@@ -53,25 +48,25 @@ $CommandButtonBlue: #2488D8;
 //== Modifier: Medium panel (anchored right, fixed width)
 //
 .ms-Panel.ms-Panel--md {
-  max-width: $Panel-width-md;
+  max-width: $ms-panel-width-md;
 }
 
 //== Modifier: Large panel (anchored right, fluid width)
 //
 .ms-Panel.ms-Panel--lg {
-  max-width: $Panel-width-lg;
+  max-width: $ms-panel-width-lg;
 }
 
 //== Modifier: XLarge panel (anchored right, fluid width)
 //
 .ms-Panel.ms-Panel--xl {
-  max-width: $Panel-width-xl;
+  max-width: $ms-panel-width-xl;
 }
 
 //== Modifier: XLarge panel (anchored right, fluid width)
 //
 .ms-Panel.ms-Panel--xxl {
-  max-width: $Panel-width-xxl;
+  max-width: $ms-panel-width-xxl;
 }
 
 //== Modifier: Left anchored panel (anchored left, fixed width)
@@ -118,9 +113,9 @@ $CommandButtonBlue: #2488D8;
   position: absolute;
   right: 8px;
   top: 0;
-  height: $CommandBarHeight;
-  width: $CommandBarHeight;
-  line-height: $CommandBarHeight;
+  height: $ms-panel-command-bar-height;
+  width: $ms-panel-command-bar-height;
+  line-height: $ms-panel-command-bar-height;
   outline: 0;
   padding: 0;
   color: $ms-color-neutralSecondary;
@@ -133,7 +128,7 @@ $CommandButtonBlue: #2488D8;
 
 // Scrollable content area
 .ms-Panel-contentInner {
-  margin-top: $CommandBarHeight;
+  margin-top: $ms-panel-command-bar-height;
   padding: 0 16px 20px;
   overflow-y: auto;
 
@@ -159,81 +154,5 @@ $CommandButtonBlue: #2488D8;
 
   @media (min-width: $ms-screen-xl-min) {
     margin-top: 30px;
-  }
-}
-
-//== Modifier: Deprecated Animated commandbar
-//
-.ms-Panel.ms-Panel--animatedCommands {
-  .ms-CommandBar {
-    @media (min-width: $ms-screen-md-min) {
-      display: block;
-    }
-  }
-
-  .ms-CommandBarItem {
-    user-select: none;
-
-    &:hover {
-      background-color: $CommandButtonLighterBlue;
-    }
-
-    &:active {
-      background-color: $CommandButtonLightBlue;
-
-      .ms-CommandBarItem-icon {
-        color: $CommandButtonDarkBlue;;
-      }
-
-      .ms-CommandBarItem-commandText {
-        color: $ms-color-black;
-      }
-    }
-  }
-
-  .ms-CommandBarItem:first-child {
-    background-color: $ms-color-themePrimary;
-    box-shadow: inset 0 1px 0 0 $CommandButtonBlue;
-
-    .ms-CommandBarItem-icon {
-      color: $ms-color-white;
-    }
-
-    .ms-CommandBarItem-commandText {
-      color: $ms-color-white;
-    }
-
-    .ms-CommandBarItem-linkWrapper {
-      padding-left: 12px;
-      padding-right: 12px;
-      cursor: pointer;
-    }
-
-    &:hover {
-      background-color: $ms-color-themeDark;
-      box-shadow: none;
-
-      .ms-CommandBarItem-icon {
-        color: $ms-color-white;
-      }
-
-      .ms-CommandBarItem-commandText {
-        color: $ms-color-white;
-      }
-    }
-  }
-
-  &.is-open {
-    .ms-CommandBar {
-      @include ms-u-slideDownIn20;
-      animation-delay: 250ms;
-    }
-
-    @media (min-width: $ms-screen-md-min) {
-      // Animate CommandBar in
-      .ms-CommandBar {
-        animation-delay: 500ms;
-      }
-    }
   }
 }

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -15,13 +15,13 @@ $ms-panel-margin-md: 48px;
 $ms-panel-margin-lg: 428px;
 $ms-panel-margin-xl: 176px;
 
-$ms-panel-command-bar-height: 40px;
+$ms-panel-close-button-height: 40px;
 
 // The panel itself, where the content goes.
 .ms-Panel {
   background-color: $ms-color-white;
   width: 100%;
-  max-width: $ms-anel-width-sm;
+  max-width: $ms-panel-width-sm;
   @include drop-shadow(-30px, 0, 30px, -30px, .2);
   position: absolute;
   top: 0;
@@ -80,7 +80,6 @@ $ms-panel-command-bar-height: 40px;
 
   // Commands and content inner are not displayed
   // Note: Replace with a leftnav menu.
-  .ms-Panel-commands,
   .ms-Panel-contentInner {
     display: none;
   }
@@ -113,9 +112,9 @@ $ms-panel-command-bar-height: 40px;
   position: absolute;
   right: 8px;
   top: 0;
-  height: $ms-panel-command-bar-height;
-  width: $ms-panel-command-bar-height;
-  line-height: $ms-panel-command-bar-height;
+  height: $ms-panel-close-button-height;
+  width: $ms-panel-close-button-height;
+  line-height: $ms-panel-close-button-height;
   outline: 0;
   padding: 0;
   color: $ms-color-neutralSecondary;
@@ -128,7 +127,7 @@ $ms-panel-command-bar-height: 40px;
 
 // Scrollable content area
 .ms-Panel-contentInner {
-  margin-top: $ms-panel-command-bar-height;
+  margin-top: $ms-panel-close-button-height;
   padding: 0 16px 20px;
   overflow-y: auto;
 

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -71,38 +71,17 @@ $ms-panel-close-button-height: 40px;
 
 //== Modifier: Left anchored panel (anchored left, fixed width)
 // Note: This panel variant should only be used for left nav.
-.ms-PanelHost.ms-PanelHost--left {
-  right: auto;
-  left: 0;
-  border-left: 1px solid $ms-color-neutralLight;
-  border-right: 1px solid $ms-color-neutralLight;
+.ms-Panel--left {
   @include drop-shadow(-30px, 0, 30px, 30px, .2);
+  left: 0;
+  right: auto;
 
-  // Commands and content inner are not displayed
-  // Note: Replace with a leftnav menu.
-  .ms-Panel-contentInner {
-    display: none;
+  &.animate-in {
+    @include ms-u-slideRightIn40;
   }
 
-  // Animations - Left panel (anchored left)
-  &.ms-Panel-animateIn {
-    .ms-Panel-main {
-      @include ms-u-slideRightIn40;
-    }
-
-    .ms-Overlay {
-      @include ms-u-fadeIn200;
-    }
-  }
-
-  &.ms-Panel--left.ms-Panel-animateOut {
-    .ms-Panel-main {
-      @include ms-u-slideLeftOut40;
-    }
-
-    .ms-Overlay {
-      @include ms-u-fadeOut200;
-    }
+  &.animate-out {
+    @include ms-u-slideLeftOut40;
   }
 }
 

--- a/src/components/PanelHost/PanelHost.hbs
+++ b/src/components/PanelHost/PanelHost.hbs
@@ -1,5 +1,3 @@
 <div class="ms-PanelHost">
-  <div class="ms-PanelHost-inner">
-  </div>
   {{> Overlay }}
 </div>

--- a/src/components/PanelHost/PanelHost.scss
+++ b/src/components/PanelHost/PanelHost.scss
@@ -1,5 +1,3 @@
-$Panel-width-lightDismiss: 272px;
-
 // The panel covers the entire screen.
 .ms-PanelHost {
   bottom: 0;
@@ -7,90 +5,5 @@ $Panel-width-lightDismiss: 272px;
   position: absolute;
   right: 0;
   top: 0;
-  pointer-events: none;
   z-index: $ms-zIndex-front;
-  font-family: $ms-font-family-base;
-}
-
-//== State: When the panel is open.
-//
-.ms-Panel.is-open {
-  display: block;
-  opacity: 1;
-  pointer-events: auto;
-
-  .ms-Overlay {
-    display: block;
-    pointer-events: auto;
-
-    @media screen and (-ms-high-contrast: active) {
-      opacity: 0;
-    }
-  }
-
-  &.ms-Panel-animateIn {
-    @include ms-u-fadeIn100;
-  }
-
-  &.ms-Panel-animateOut {
-    @include ms-u-fadeOut100;
-
-    .ms-Overlay {
-      display: none;
-    }
-  }
-
-  // Medium screens and up
-  @media (min-width: $ms-screen-md-min) {
-    // Animations -- Default (anchored right)
-    &.ms-Panel-animateIn {
-      @include ms-u-slideLeftIn40;
-
-      .ms-Overlay {
-        @include ms-u-fadeIn200;
-      }
-    }
-
-    &.ms-Panel-animateOut {
-      @include ms-u-slideRightOut40;
-
-      .ms-Overlay {
-        @include ms-u-fadeOut200;
-      }
-    }
-
-    // Animations - Left panel (anchored left)
-    &.ms-Panel--left.ms-Panel-animateIn {
-      @include ms-u-slideRightIn40;
-
-      .ms-Overlay {
-        @include ms-u-fadeIn200;
-      }
-    }
-
-    &.ms-Panel--left.ms-Panel-animateOut {
-      @include ms-u-slideLeftOut40;
-
-      .ms-Overlay {
-        @include ms-u-fadeOut200;
-      }
-    }
-
-    // Animate overlay to full opacity, activate pointer events
-    .ms-Overlay {
-      cursor: pointer;
-      opacity: 1;
-      pointer-events: auto;
-    }
-
-    &.ms-Panel-animateIn,
-    &.ms-Panel--left.ms-Panel-animateIn {
-      .ms-Overlay {
-        @media screen and (-ms-high-contrast: active) {
-          opacity: 0;
-          animation-name: none;
-        }
-      }
-    }
-  }
 }

--- a/src/components/PanelHost/PanelHost.scss
+++ b/src/components/PanelHost/PanelHost.scss
@@ -7,3 +7,7 @@
   top: 0;
   z-index: $ms-zIndex-front;
 }
+
+.ms-PanelHost .ms-Overlay {
+  cursor: pointer;
+}

--- a/src/documentation/pages/Panel/Panel.md
+++ b/src/documentation/pages/Panel/Panel.md
@@ -33,6 +33,12 @@ Presents content by sliding over the rest of the application, which is covered b
 {{> PanelExtraExtraLargeExample}}
 --->
 
+### Left aligned
+You can add the `ms-Panel--left` modifier to any panel to attach it to the left side of the screen.
+<!---
+{{> PanelLeftExample}}
+--->
+
 ## States
 State | Applied to | Result
  --- | --- | ---

--- a/src/documentation/pages/Panel/examples/PanelExampleProps.js
+++ b/src/documentation/pages/Panel/examples/PanelExampleProps.js
@@ -5,29 +5,7 @@
       "tag": "button"
     },
     "headerText": "Panel",
-    "content": "Content goes here",
-    "commandBarProps": {
-      "commands": [
-        {
-          "component": "CommandButton",
-          "props":  {
-            "label": "Save",
-            "icon": "save",
-            "tag": "button",
-            "iconColor": "themePrimary"
-          }
-        },
-        {
-          "component": "CommandButton",
-          "props":  {
-            "label": "Cancel",
-            "icon": "x",
-            "tag": "button",
-            "iconColor": "themePrimary"
-          }
-        }
-      ]
-    }
+    "content": "Content goes here"
   },
   "medium": {
     "button": {

--- a/src/documentation/pages/Panel/examples/PanelExampleProps.js
+++ b/src/documentation/pages/Panel/examples/PanelExampleProps.js
@@ -74,7 +74,20 @@
         "name": "xxl"
       }
     ]
-  }
+  },
+  "left": {
+    "button": {
+      "label": "Open Panel",
+      "tag": "button"
+    },
+    "headerText": "Left Panel",
+    "content": "Content goes here",
+    "modifier": [
+      {
+        "name": "left"
+      }
+    ]
+  },
 }
 
 module.exports = PanelExampleProps;

--- a/src/documentation/pages/Panel/examples/PanelLeftExample.hbs
+++ b/src/documentation/pages/Panel/examples/PanelLeftExample.hbs
@@ -1,0 +1,12 @@
+<div class="ms-PanelLeftExample">
+    {{> Button props=PanelExampleProps.left.button}}
+    {{> Panel props=PanelExampleProps.left}}
+</div>
+
+<script>
+  var PanelLeftExampleButton = document.querySelector(".ms-PanelLeftExample .ms-Button");
+  var PanelLeftExamplePanel = document.querySelector(".ms-PanelLeftExample .ms-Panel");
+  PanelLeftExampleButton.addEventListener("click", function() {
+    new fabric['Panel'](PanelLeftExamplePanel);
+  });
+</script>

--- a/src/sass/Fabric.Components.scss
+++ b/src/sass/Fabric.Components.scss
@@ -23,6 +23,7 @@
 @import '../components/OrgChart/OrgChart';
 @import '../components/Overlay/Overlay';
 @import '../components/Panel/Panel';
+@import '../components/PanelHost/PanelHost';
 @import '../components/PeoplePicker/PeoplePicker';
 @import '../components/Persona/Persona';
 @import '../components/PersonaCard/PersonaCard';


### PR DESCRIPTION
Fixes #511 

The `ms-Panel--left` modifier can now be used to attach the Panel to the left side of the screen, with the appropriate animations:

![image](https://cloud.githubusercontent.com/assets/1382445/16140831/a5b322c8-3409-11e6-8e7c-b9a5b6f48e3a.png)
