### PR TITLE
Fix Sass linting issues and build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-file-include": "^0.13.7",
     "gulp-folders": "^1.1.0",
     "gulp-foreach": "^0.1.0",
-    "gulp-header": "^1.2.2",
+    "gulp-header": "1.8.2",
     "gulp-html-prettify": "0.0.1",
     "gulp-if": "^2.0.0",
     "gulp-jshint": "^2.0.0",

--- a/src/components/Breadcrumb/Breadcrumb.scss
+++ b/src/components/Breadcrumb/Breadcrumb.scss
@@ -74,7 +74,7 @@
     z-index: ($ms-zIndex-ContextualMenu + $ms-zIndex-middle);
   }
 
-  &:before {
+  &::before {
     position: absolute;
     @include drop-shadow;
     top: -6px;

--- a/src/components/CheckBox/CheckBox.scss
+++ b/src/components/CheckBox/CheckBox.scss
@@ -26,12 +26,12 @@
     pointer-events: none;
     cursor: default;
 
-    &:before {
+    &::before {
       background-color: $ms-color-neutralTertiaryAlt;
       color: $ms-color-neutralTertiaryAlt;
     }
 
-    &:after {
+    &::after {
       border-color: $ms-color-neutralLight;
     }
 
@@ -40,7 +40,7 @@
     }
   }
 
-  & .ms-CheckBox-field.in-focus:after {
+  & .ms-CheckBox-field.in-focus::after {
     border-color: $ms-color-neutralSecondaryAlt;
   }
 
@@ -52,7 +52,7 @@
     position: relative;
 
     // The actual styled CheckBox element - radio button by default
-    &:after {
+    &::after {
       content: '';
       display: inline-block;
       border: 1px $ms-color-neutralTertiaryAlt solid;
@@ -67,7 +67,7 @@
     }
 
     &:hover {
-      &:after {
+      &::after {
         border-color: $ms-color-neutralSecondaryAlt;
       }
 
@@ -77,13 +77,13 @@
     }
 
     &.ms-Choice-type--checkbox {
-      &:after {
+      &::after {
         border-radius: 0;
       }
 
       &.is-checked {
-        &:hover:before,
-        &:before {
+        &:hover::before,
+        &::before {
           @include ms-Icon;
           content: '\e041';
           background-color: transparent;
@@ -98,7 +98,7 @@
     // Radio button by default
     &.is-checked {
       // Circle indicating a checked radio button
-      &:before {
+      &::before {
         background-color: $ms-color-neutralSecondary;
         border-color: $ms-color-neutralSecondary;
         color: $ms-color-neutralSecondary;
@@ -115,7 +115,7 @@
         box-sizing: border-box;
       }
 
-      &:hover:before {
+      &:hover::before {
         background-color: $ms-color-neutralDark;
         color: $ms-color-neutralDark;
       }

--- a/src/components/CommandButton/CommandButton.scss
+++ b/src/components/CommandButton/CommandButton.scss
@@ -228,7 +228,7 @@ $CommandButton-padding: 8px;
 //
 .ms-CommandButton.ms-CommandButton--pivot {
 
-  &.is-active:before {
+  &.is-active::before {
     @include ms-CommandButton-pivotLine;
   }
 

--- a/src/components/ContextualMenu/ContextualMenu.scss
+++ b/src/components/ContextualMenu/ContextualMenu.scss
@@ -142,7 +142,7 @@
       background-color: $ms-color-white;
 
       // Checkmark
-      &:after {
+      &::after {
         @include ms-Icon;
         color: $ms-color-neutralPrimary;
         content: '\e041';

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -151,7 +151,7 @@
 
 
 // Disabled day.
-.ms-DatePicker-day--disabled:before {
+.ms-DatePicker-day--disabled::before {
     border-top-color: $ms-color-neutralTertiary;
 }
 

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -111,7 +111,7 @@
     padding: 0 16px;
   }
 
-  &:before {
+  &::before {
     content: none;
     border: 0;
   }
@@ -165,7 +165,7 @@
   left: auto;
   max-width: 100%;
 
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     z-index: -1;

--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -10,7 +10,7 @@
 }
 
 @mixin ms-Label-is-required {
-  &:after {
+  &::after {
     content: ' *';
     color: $ms-color-error;
   }

--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -123,7 +123,7 @@
 //== State: Unseen list item
 //
 .ms-ListItem.is-unseen {
-  &:after {
+  &::after {
     border-right: 10px solid transparent;
     border-top: 10px solid $ms-color-themePrimary;
     left: 0;
@@ -155,7 +155,7 @@
     outline: 1px solid transparent;
 
     // Insert the empty box.
-    &:before {
+    &::before {
       @include ms-Icon;
       position: absolute;
       top: 12px;
@@ -172,12 +172,12 @@
 //
 .ms-ListItem.is-selected {
   // Insert the checkmark.
-  &:before {
+  &::before {
     border: 1px solid transparent;
   }
 
-  &:before,
-  &:hover:before {
+  &::before,
+  &:hover::before {
     @include ms-Icon;
     content: '\e041';
     font-size: $ms-font-size-m-plus;

--- a/src/components/MessageBar/MessageBar.scss
+++ b/src/components/MessageBar/MessageBar.scss
@@ -88,11 +88,11 @@ $MessageBar-padding: 8px;
     font-size: $ms-font-size-s;
     top: 3px;
 
-    &:before {
+    &::before {
       margin-left: 1px;
     }
 
-    &:after {
+    &::after {
       font-size: 8px;
       margin-left: 3px;
       top: 1px;

--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -563,7 +563,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-presence {
     background-color: $ms-color-white;
 
-    &:before {
+    &::before {
       content: '';
       width: 100%;
       height: 100%;
@@ -574,7 +574,7 @@ $ms-Persona-presenceSizeXl: 28px;
       border-radius: 50%;
     }
 
-    &:after {
+    &::after {
       content: '';
       width: 100%;
       height: 2px;
@@ -588,7 +588,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
   &.ms-Persona--lg {
     .ms-Persona-presence {
-      &:after {
+      &::after {
         top: 9px;
       }
     }
@@ -596,7 +596,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
   &.ms-Persona--xl {
     .ms-Persona-presence {
-      &:after {
+      &::after {
         top: 13px;
       }
     }

--- a/src/components/PersonaCard/PersonaCard.scss
+++ b/src/components/PersonaCard/PersonaCard.scss
@@ -60,7 +60,7 @@
     color: $ms-color-themePrimary;
   }
 
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     width: 100%;
@@ -76,7 +76,7 @@
     color: $ms-color-themePrimary;
 
     // Arrow
-    &:after {
+    &::after {
       @include ms-u-borderBox;
       @include rotate(45deg);
       content: '';
@@ -138,7 +138,7 @@
     overflow: hidden;
 
     // Show the expander icon.
-    .ms-PersonaCard-detailExpander:after {
+    .ms-PersonaCard-detailExpander::after {
       content: '\e088';
     }
   }
@@ -161,7 +161,7 @@
   text-align: center;
   width: 30px;
 
-  &:after {
+  &::after {
     @include ms-Icon;
     content: '\e087';
   }
@@ -177,7 +177,7 @@
 }
 
 .ms-PersonaCard-action.ms-PersonaCard-orgChart {
-  &:after {
+  &::after {
     display: none; // Hide arrow for orgchart action
   }
 }

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -89,7 +89,7 @@
   }
 
   .ms-Pivot-link.ms-Pivot-link--overflow {
-    &:after {
+    &::after {
       font-size: $ms-font-size-l;
     }
   }
@@ -145,7 +145,7 @@
   }
 
   .ms-Pivot-link.ms-Pivot-link--overflow {
-    &:after {
+    &::after {
       font-size: $ms-font-size-m;
     }
   }

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -26,12 +26,12 @@
     pointer-events: none;
     cursor: default;
 
-    &:before {
+    &::before {
       background-color: $ms-color-neutralTertiaryAlt;
       color: $ms-color-neutralTertiaryAlt;
     }
 
-    &:after {
+    &::after {
       border-color: $ms-color-neutralLight;
     }
 
@@ -40,7 +40,7 @@
     }
   }
 
-  & .ms-Choice-type--radio.in-focus:after {
+  & .ms-Choice-type--radio.in-focus::after {
     border-color: $ms-color-neutralSecondaryAlt;
   }
 
@@ -52,7 +52,7 @@
     position: relative;
 
     // The actual styled RadioButton element - radio button by default
-    &:after {
+    &::after {
       content: '';
       display: inline-block;
       border: 1px $ms-color-neutralTertiaryAlt solid;
@@ -67,7 +67,7 @@
     }
 
     &:hover {
-      &:after {
+      &::after {
         border-color: $ms-color-neutralSecondaryAlt;
       }
 
@@ -79,7 +79,7 @@
     // Radio button by default
     &.is-checked {
       // Circle indicating a checked radio button
-      &:before {
+      &::before {
         background-color: $ms-color-neutralSecondary;
         border-color: $ms-color-neutralSecondary;
         color: $ms-color-neutralSecondary;
@@ -96,7 +96,7 @@
         box-sizing: border-box;
       }
 
-      &:hover:before {
+      &:hover::before {
         background-color: $ms-color-neutralDark;
         color: $ms-color-neutralDark;
       }

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -34,12 +34,12 @@
       background-color: $ms-color-themePrimary;
 
       // Hide the checkbox.
-      &:before {
+      &::before {
         display: none;
       }
 
       // But show the mark.
-      &:after {
+      &::after {
         @include ms-Icon;
         content: '\e041';
         color: $ms-color-white;
@@ -99,7 +99,7 @@
   padding: 0;
 
   // Empty checkbox.
-  &:before {
+  &::before {
     border: 1px solid $ms-color-neutralTertiary;
     content: '';
     display: block;
@@ -131,7 +131,7 @@
         background: none;
 
         // Show the checkbox.
-        &:before {
+        &::before {
           display: block;
         }
       }

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -11,7 +11,7 @@
 // Slider mixin
 @mixin ms-Toggle-slider($direction) {
   // Slider pseudo element
-  &:before {
+  &::before {
     position: absolute;
     display: block;
     box-sizing: content-box;
@@ -35,14 +35,14 @@
   }
 
   @if $direction == left {
-    &:before {
+    &::before {
       right: auto;
       border-right: 2.5px solid $ms-color-white;
     }
   }
 
   @if $direction == right {
-    &:before {
+    &::before {
       left: auto;
       border-left: 2.5px solid $ms-color-white;
     }
@@ -149,13 +149,13 @@
       pointer-events: none;
       cursor: default;
 
-      &:before {
+      &::before {
         background-color: $ms-color-neutralTertiaryAlt;
       }
     }
 
     .ms-Toggle-field,
-    .ms-Toggle-field:before {
+    .ms-Toggle-field::before {
       @media screen and (-ms-high-contrast: active) {
         border-color: $ms-color-contrastBlackDisabled;
       }


### PR DESCRIPTION
Fix for issue #673 and should allow PR #670 to build without errors.

A recent update to the Sass linter added a new rule that we were failing. All pseudo-elements now have two colons: `::after` and `::before` to differentiate them from pseudo-classes like `:hover`.

There was also a build error (see #673) that turned out to be caused by the latest release of gulp-header. I've updated package.json so that we pull in the latest working version.