### PR TITLE
Mistaken code comment in textfield.ts

### DIFF
--- a/src/components/TextField/TextField.ts
+++ b/src/components/TextField/TextField.ts
@@ -55,7 +55,7 @@ namespace fabric {
           this._textFieldLabel.style.display = "none";
         });
         this._textField.addEventListener("blur", (event: MouseEvent) => {
-          // Hide only if no value in the text field
+          // Show only if no value in the text field
           if (this._textField.value.length === 0) {
             this._textFieldLabel.style.display = "block";
           }


### PR DESCRIPTION
The code DISPLAYS the placeholder text (as it should) when there is no
other value to the field; so the code comment said the opposite of what
the code actually does (and should do).